### PR TITLE
Auto approve dependabot PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,17 @@
+name: Auto approve
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: hmarr/auto-approve-action@v4
+        with:
+          review-message: "Auto approved automated PR"


### PR DESCRIPTION
This gives 1 approval to dependabot PRs, so only 1 additional approval is needed. This should remove the friction with updating dependencies.

It uses this github action: https://github.com/hmarr/auto-approve-action

- It still requires additional review from another team member, so it cannot merge something we don't want.
- It cannot approve other PRs.