### PR TITLE
chore: git ignore dependencies copied into contracts/external

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,6 @@ node_modules
 /coverage
 /coverage.json
 
-contracts/external/boson-protocol-contracts
+contracts/external
 
 /addresses/31337-*


### PR DESCRIPTION
When I run yarn in the repository, all files copied from seaport dependency to the `contracts/external/seaport` folder appear new for GIT.
I just replace `contracts/external/boson-protocol-contracts` with `contracts/external` in .gitignore to fix that issue.
