### PR TITLE
ERC2771 support for metatransactions

### DIFF
--- a/contracts/protocol/bases/mixins/FundsManager.sol
+++ b/contracts/protocol/bases/mixins/FundsManager.sol
@@ -6,11 +6,11 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ERC2771Context } from "@openzeppelin/contracts/metatx/ERC2771Context.sol";
 import { FundsErrors, FermionGeneralErrors } from "../../domain/Errors.sol";
 import { FermionStorage } from "../../libs/Storage.sol";
 import { ContextLib } from "../../libs/ContextLib.sol";
 import { FermionFNFTLib } from "../../libs/FermionFNFTLib.sol";
-import { IFermionFNFT } from "../../interfaces/IFermionFNFT.sol";
 import { IFundsEvents } from "../../interfaces/events/IFundsEvents.sol";
 
 /**
@@ -67,7 +67,7 @@ contract FundsManager {
      * N.B. Special caution is needed when interacting with the FermionFNFT contract,
      * as it treats _msgSender() differently when the caller is the Fermion protocol.
      * If FundsLib methods are used in the contracts that are not part of the diamond,
-     * `checkFNFTContract` should be overridden to return false.
+     * `checkTrustedForwarder` should be overridden to return false.
      *
      * @param _tokenAddress - address of the token to be transferred
      * @param _from - address to transfer funds from
@@ -78,7 +78,14 @@ contract FundsManager {
         isERC721Contract(_tokenAddress, false);
 
         uint256 protocolTokenBalanceBefore = IERC20(_tokenAddress).balanceOf(address(this));
-        IERC20(_tokenAddress).safeTransferFrom(_from, address(this), _amount);
+
+        // transfer ERC20 tokens from the caller
+        if (checkTrustedForwarder(_tokenAddress)) {
+            _tokenAddress.transferFrom(_from, address(this), _amount);
+        } else {
+            IERC20(_tokenAddress).safeTransferFrom(_from, address(this), _amount);
+        }
+
         uint256 protocolTokenBalanceAfter = IERC20(_tokenAddress).balanceOf(address(this));
 
         // make sure that expected amount of tokens was transferred
@@ -164,7 +171,12 @@ contract FundsManager {
             (bool success, bytes memory errorMessage) = _to.call{ value: _amount }("");
             if (!success) revert FundsErrors.TokenTransferFailed(_to, _amount, errorMessage);
         } else {
-            IERC20(_tokenAddress).safeTransfer(_to, _amount);
+            // transfer ERC20 tokens
+            if (checkTrustedForwarder(_tokenAddress)) {
+                _tokenAddress.transfer(_to, _amount);
+            } else {
+                IERC20(_tokenAddress).safeTransfer(_to, _amount);
+            }
         }
     }
 
@@ -175,8 +187,12 @@ contract FundsManager {
      *
      * @param _tokenAddress - address of the token to be transferred
      */
-    function checkFNFTContract(address _tokenAddress) internal view virtual returns (bool) {
-        return _tokenAddress.codehash == FNFT_CODEHASH;
+    function checkTrustedForwarder(address _tokenAddress) internal view virtual returns (bool) {
+        try ERC2771Context(_tokenAddress).trustedForwarder() returns (address trustedForwarder) {
+            return trustedForwarder == address(this);
+        } catch {
+            return false;
+        }
     }
 
     /**
@@ -250,7 +266,7 @@ contract FundsManager {
         isERC721Contract(_tokenAddress, true);
 
         // transfer ERC721 tokens from the caller
-        if (checkFNFTContract(_tokenAddress)) {
+        if (checkTrustedForwarder(_tokenAddress)) {
             _tokenAddress.transferFrom(_from, address(this), _tokenId);
         } else {
             IERC721(_tokenAddress).transferFrom(_from, address(this), _tokenId);
@@ -277,7 +293,7 @@ contract FundsManager {
         // 2. If the buyer is withdrawing the token, they cannot plug in an arbitrary token address
 
         // transfer ERC721 tokens from the protocol
-        if (checkFNFTContract(_tokenAddress)) {
+        if (checkTrustedForwarder(_tokenAddress)) {
             _tokenAddress.safeTransferFrom(address(this), _to, _tokenId);
         } else {
             IERC721(_tokenAddress).safeTransferFrom(address(this), _to, _tokenId);

--- a/contracts/protocol/bases/mixins/FundsManager.sol
+++ b/contracts/protocol/bases/mixins/FundsManager.sol
@@ -22,12 +22,6 @@ contract FundsManager {
     using SafeERC20 for IERC20;
     using FermionFNFTLib for address;
 
-    bytes32 private immutable FNFT_CODEHASH;
-
-    constructor(bytes32 _fnftCodeHash) {
-        FNFT_CODEHASH = _fnftCodeHash;
-    }
-
     /**
      * @notice Validates that incoming payments matches expectation. If token is a native currency, it makes sure
      * msg.value is correct. If token is ERC20, it transfers the value from the sender to the protocol.

--- a/contracts/protocol/clients/FermionBuyoutAuction.sol
+++ b/contracts/protocol/clients/FermionBuyoutAuction.sol
@@ -24,7 +24,7 @@ contract FermionBuyoutAuction is
     IFermionFractionsEvents
 {
     using Address for address;
-    constructor(address _bosonPriceDiscovery) FermionFNFTBase(_bosonPriceDiscovery) FundsManager(bytes32(0)) {}
+    constructor(address _bosonPriceDiscovery) FermionFNFTBase(_bosonPriceDiscovery) {}
 
     /**
      * @notice Starts the auction for a specific fractionalized token. Can be called by anyone.

--- a/contracts/protocol/clients/FermionFNFT.sol
+++ b/contracts/protocol/clients/FermionFNFT.sol
@@ -9,7 +9,6 @@ import { IFermionFNFT } from "../interfaces/IFermionFNFT.sol";
 import { FermionFractions } from "./FermionFractions.sol";
 import { FermionWrapper } from "./FermionWrapper.sol";
 import { Common } from "./Common.sol";
-import { FundsManager } from "../bases/mixins/FundsManager.sol";
 import { ERC721Upgradeable as ERC721 } from "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import { ContextUpgradeable as Context } from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import { ERC2771ContextUpgradeable as ERC2771Context } from "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
@@ -39,7 +38,6 @@ contract FermionFNFT is FermionFractions, FermionWrapper, ERC2771Context, IFermi
     )
         FermionWrapper(_bosonPriceDiscovery, _seaportWrapper, _wrappedNative)
         ERC2771Context(address(0))
-        FundsManager(bytes32(0))
         FermionFractions(_fnftFractionMint, _fermionFNFTPriceManager, _fnftBuyoutAuction)
     {}
 

--- a/contracts/protocol/clients/FermionFractionsERC20.sol
+++ b/contracts/protocol/clients/FermionFractionsERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20PermitUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IFermionFNFTPriceManager } from "../interfaces/IFermionFNFTPriceManager.sol";
@@ -12,7 +12,7 @@ import { ERC2771ContextUpgradeable as ERC2771Context } from "@openzeppelin/contr
  * @dev Implementation of the Fermion Fractions ERC20 epoch token.
  * This implementation is designed to be used with minimal proxies (EIP-1167).
  */
-contract FermionFractionsERC20 is Initializable, ERC20Upgradeable, ERC2771Context, OwnableUpgradeable {
+contract FermionFractionsERC20 is Initializable, ERC20PermitUpgradeable, ERC2771Context, OwnableUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _fermionProtocol) ERC2771Context(_fermionProtocol) {
         _disableInitializers();
@@ -24,6 +24,7 @@ contract FermionFractionsERC20 is Initializable, ERC20Upgradeable, ERC2771Contex
      */
     function initialize(string memory name_, string memory symbol_, address owner_) external initializer {
         __ERC20_init(name_, symbol_);
+        __ERC20Permit_init(name_);
         __Ownable_init(owner_);
     }
 

--- a/contracts/protocol/clients/FermionFractionsERC20.sol
+++ b/contracts/protocol/clients/FermionFractionsERC20.sol
@@ -5,14 +5,16 @@ import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC2
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { IFermionFNFTPriceManager } from "../interfaces/IFermionFNFTPriceManager.sol";
+import { ContextUpgradeable as Context } from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import { ERC2771ContextUpgradeable as ERC2771Context } from "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
 
 /**
  * @dev Implementation of the Fermion Fractions ERC20 epoch token.
  * This implementation is designed to be used with minimal proxies (EIP-1167).
  */
-contract FermionFractionsERC20 is Initializable, ERC20Upgradeable, OwnableUpgradeable {
+contract FermionFractionsERC20 is Initializable, ERC20Upgradeable, ERC2771Context, OwnableUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor() {
+    constructor(address _fermionProtocol) ERC2771Context(_fermionProtocol) {
         _disableInitializers();
     }
 
@@ -62,5 +64,17 @@ contract FermionFractionsERC20 is Initializable, ERC20Upgradeable, OwnableUpgrad
         if (from != address(0) && to != address(0)) {
             IFermionFNFTPriceManager(owner()).adjustVotesOnTransfer(from, value);
         }
+    }
+
+    function _msgSender() internal view virtual override(Context, ERC2771Context) returns (address) {
+        return ERC2771Context._msgSender();
+    }
+
+    function _msgData() internal view virtual override(Context, ERC2771Context) returns (bytes calldata) {
+        return ERC2771Context._msgData();
+    }
+
+    function _contextSuffixLength() internal view virtual override(Context, ERC2771Context) returns (uint256) {
+        return ERC2771Context._contextSuffixLength();
     }
 }

--- a/contracts/protocol/clients/FermionFractionsMint.sol
+++ b/contracts/protocol/clients/FermionFractionsMint.sol
@@ -29,10 +29,7 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
      * @param _bosonPriceDiscovery The address of the Boson Price Discovery contract
      * @param _erc20Implementation The address of the ERC20 implementation contract that will be cloned
      */
-    constructor(
-        address _bosonPriceDiscovery,
-        address _erc20Implementation
-    ) FermionFNFTBase(_bosonPriceDiscovery) FundsManager(bytes32(0)) {
+    constructor(address _bosonPriceDiscovery, address _erc20Implementation) FermionFNFTBase(_bosonPriceDiscovery) {
         if (_erc20Implementation == address(0)) revert FermionGeneralErrors.InvalidAddress();
         erc20Implementation = _erc20Implementation;
     }

--- a/contracts/protocol/facets/Custody.sol
+++ b/contracts/protocol/facets/Custody.sol
@@ -22,8 +22,6 @@ import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 contract CustodyFacet is Context, CustodyErrors, Access, Custody, ICustodyEvents, IFundsEvents {
     using FermionFNFTLib for address;
 
-    constructor(bytes32 _fnftCodeHash) FundsManager(_fnftCodeHash) {}
-
     /**
      * @notice Notifies the protocol that an RWA has been checked in
      *

--- a/contracts/protocol/facets/CustodyVault.sol
+++ b/contracts/protocol/facets/CustodyVault.sol
@@ -21,7 +21,6 @@ import { IFermionFNFT } from "../interfaces/IFermionFNFT.sol";
  */
 contract CustodyVaultFacet is Context, CustodianVaultErrors, Access, Custody, ICustodyEvents {
     using FermionFNFTLib for address;
-    constructor(bytes32 _fnftCodeHash) FundsLib(_fnftCodeHash) {}
 
     /**
      * @notice When the first NFT is fractionalised, the custodian offer vault is setup.

--- a/contracts/protocol/facets/Funds.sol
+++ b/contracts/protocol/facets/Funds.sol
@@ -16,9 +16,7 @@ import { FundsManager } from "../bases/mixins/FundsManager.sol";
  *
  * @notice Handles entity funds.
  */
-contract FundsFacet is Context, FundsErrors, Access, FundsManager, IFundsEvents {
-    constructor(bytes32 _fnftCodeHash) FundsManager(_fnftCodeHash) {}
-
+contract FundsFacet is Context, FundsErrors, Access, FundsLib, IFundsEvents {
     /**
      * @notice Receives funds from the caller, maps funds to the entity id and stores them so they can be used during unwrapping.
      *

--- a/contracts/protocol/facets/Funds.sol
+++ b/contracts/protocol/facets/Funds.sol
@@ -16,7 +16,7 @@ import { FundsManager } from "../bases/mixins/FundsManager.sol";
  *
  * @notice Handles entity funds.
  */
-contract FundsFacet is Context, FundsErrors, Access, FundsLib, IFundsEvents {
+contract FundsFacet is Context, FundsErrors, Access, FundsManager, IFundsEvents {
     /**
      * @notice Receives funds from the caller, maps funds to the entity id and stores them so they can be used during unwrapping.
      *

--- a/contracts/protocol/facets/MetaTransaction.sol
+++ b/contracts/protocol/facets/MetaTransaction.sol
@@ -8,6 +8,7 @@ import { FermionStorage } from "../libs/Storage.sol";
 import { Access } from "../bases/mixins/Access.sol";
 import { IMetaTransactionEvents } from "../interfaces/events/IMetaTransactionEvents.sol";
 import { EIP712 } from "../libs/EIP712.sol";
+import { IFermionFNFT } from "../interfaces/IFermionFNFT.sol";
 
 /**
  * @title MetaTransactionFacet
@@ -58,7 +59,7 @@ contract MetaTransactionFacet is Access, EIP712, MetaTransactionErrors, IMetaTra
      * @param _functionSignature - the function signature
      * @param _nonce - the nonce value of the transaction
      * @param _sig - meta transaction signature, r, s, v
-     * @param _offerId - the offer ID, if FermionFNFT is called. 0 for this contract.
+     * @param _offerIdWithEpoch - the offer ID, if FermionFNFT or {epoch+1}{offerId} Fermion Fraction is called or 0 for this contract.
      */
     function executeMetaTransaction(
         address _userAddress,
@@ -66,7 +67,7 @@ contract MetaTransactionFacet is Access, EIP712, MetaTransactionErrors, IMetaTra
         bytes calldata _functionSignature,
         uint256 _nonce,
         Signature calldata _sig,
-        uint256 _offerId
+        uint256 _offerIdWithEpoch
     ) external payable notPaused(FermionTypes.PausableRegion.MetaTransaction) nonReentrant returns (bytes memory) {
         address userAddress = _userAddress; // stack too deep workaround.
         validateTx(_functionName, _functionSignature, _nonce, userAddress);
@@ -74,15 +75,36 @@ contract MetaTransactionFacet is Access, EIP712, MetaTransactionErrors, IMetaTra
         FermionTypes.MetaTransaction memory metaTx;
         metaTx.nonce = _nonce;
         metaTx.from = userAddress;
-        metaTx.contractAddress = _offerId == 0
-            ? address(this)
-            : FermionStorage.protocolLookups().offerLookups[_offerId].fermionFNFTAddress;
+        metaTx.contractAddress = getContractAddress(_offerIdWithEpoch);
         metaTx.functionName = _functionName;
         metaTx.functionSignature = _functionSignature;
 
         verify(userAddress, hashMetaTransaction(metaTx), _sig);
 
         return executeTx(metaTx.contractAddress, userAddress, _functionName, _functionSignature, _nonce);
+    }
+
+    /**
+     * @notice Gets the destination contract address from the storage.
+     *
+     * If the offerIdWithEpoch is 0, returns the address of this contract.
+     * If not, the upper 128 bits are represents the epoch+1
+     * If epoch is -1, returns the address of the FermionFNFT contract.
+     * Otherwise, returns the address of the ERC20 clone for the specific epoch.
+     *
+     * @param _offerIdWithEpoch - the offer ID, if FermionFNFT or {epoch+1}{offerId} Fermion Fraction is called or 0 for this contract.
+     */
+    function getContractAddress(uint256 _offerIdWithEpoch) internal view returns (address) {
+        if (_offerIdWithEpoch == 0) return address(this);
+
+        uint256 epoch = _offerIdWithEpoch >> 128;
+        uint256 offerId = _offerIdWithEpoch & type(uint128).max;
+
+        address FNFTAddress = FermionStorage.protocolLookups().offerLookups[offerId].fermionFNFTAddress;
+
+        if (epoch == 0) return FNFTAddress;
+
+        return IFermionFNFT(FNFTAddress).getERC20FractionsClone(epoch - 1);
     }
 
     /**

--- a/contracts/protocol/facets/MetaTransaction.sol
+++ b/contracts/protocol/facets/MetaTransaction.sol
@@ -59,7 +59,9 @@ contract MetaTransactionFacet is Access, EIP712, MetaTransactionErrors, IMetaTra
      * @param _functionSignature - the function signature
      * @param _nonce - the nonce value of the transaction
      * @param _sig - meta transaction signature, r, s, v
-     * @param _offerIdWithEpoch - the offer ID, if FermionFNFT or {epoch+1}{offerId} Fermion Fraction is called or 0 for this contract.
+     * @param _offerIdWithEpoch - determines where the call is forwarded to. 0 is for Fermion Protocol,
+     * a plain offerId is for FermionFNFT associated with offerId, and {epoch+1}{offerId} is for FermionFractions
+     * associated with offerId and epoch.
      */
     function executeMetaTransaction(
         address _userAddress,
@@ -92,7 +94,9 @@ contract MetaTransactionFacet is Access, EIP712, MetaTransactionErrors, IMetaTra
      * If epoch is -1, returns the address of the FermionFNFT contract.
      * Otherwise, returns the address of the ERC20 clone for the specific epoch.
      *
-     * @param _offerIdWithEpoch - the offer ID, if FermionFNFT or {epoch+1}{offerId} Fermion Fraction is called or 0 for this contract.
+     * @param _offerIdWithEpoch - determines where the call is forwarded to. 0 is for Fermion Protocol,
+     * a plain offerId is for FermionFNFT associated with offerId, and {epoch+1}{offerId} is for FermionFractions
+     * associated with offerId and epoch.
      */
     function getContractAddress(uint256 _offerIdWithEpoch) internal view returns (address) {
         if (_offerIdWithEpoch == 0) return address(this);

--- a/contracts/protocol/facets/Offer.sol
+++ b/contracts/protocol/facets/Offer.sol
@@ -34,7 +34,7 @@ contract OfferFacet is Context, OfferErrors, Access, FundsManager, IOfferEvents 
     IBosonProtocol private immutable BOSON_PROTOCOL;
     address private immutable BOSON_TOKEN;
 
-    constructor(address _bosonProtocol, bytes32 _fnftCodeHash) FundsManager(_fnftCodeHash) {
+    constructor(address _bosonProtocol) {
         if (_bosonProtocol == address(0)) revert FermionGeneralErrors.InvalidAddress();
 
         BOSON_PROTOCOL = IBosonProtocol(_bosonProtocol);

--- a/contracts/protocol/facets/Verification.sol
+++ b/contracts/protocol/facets/Verification.sol
@@ -30,11 +30,7 @@ contract VerificationFacet is Context, Access, FundsManager, EIP712, Verificatio
 
     IBosonProtocol private immutable BOSON_PROTOCOL;
 
-    constructor(
-        address _bosonProtocol,
-        bytes32 _fnftCodeHash,
-        address _fermionProtocolAddress
-    ) FundsManager(_fnftCodeHash) EIP712(_fermionProtocolAddress) {
+    constructor(address _bosonProtocol, address _fermionProtocolAddress) EIP712(_fermionProtocolAddress) {
         if (_bosonProtocol == address(0)) revert FermionGeneralErrors.InvalidAddress();
         BOSON_PROTOCOL = IBosonProtocol(_bosonProtocol);
     }

--- a/contracts/protocol/interfaces/IFermionFNFT.sol
+++ b/contracts/protocol/interfaces/IFermionFNFT.sol
@@ -58,6 +58,15 @@ interface IFermionFNFT is IFermionWrapper, IFermionFractions {
     function tokenState(uint256 _tokenId) external view returns (FermionTypes.TokenState);
 
     /**
+     * @notice Returns the address of the ERC20 clone for a specific epoch
+     * Users should interact with this contract directly for ERC20 operations
+     *
+     * @param _epoch The epoch
+     * @return The address of the ERC20 clone
+     */
+    function getERC20FractionsClone(uint256 _epoch) external view returns (address);
+
+    /**
      * @notice Returns the address of the ERC20 clone for the current epoch
      * Users should interact with this contract directly for ERC20 operations
      *

--- a/contracts/protocol/libs/FermionFNFTLib.sol
+++ b/contracts/protocol/libs/FermionFNFTLib.sol
@@ -11,6 +11,7 @@ import { IFermionFractions } from "../interfaces/IFermionFractions.sol";
 import { IFermionWrapper } from "../interfaces/IFermionWrapper.sol";
 import { IFermionBuyoutAuction } from "../interfaces/IFermionBuyoutAuction.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "seaport-types/src/lib/ConsiderationStructs.sol" as SeaportTypes;
 
 /**
@@ -78,6 +79,19 @@ library FermionFNFTLib {
         _fnft.functionCallWithAddress(
             abi.encodeWithSignature("safeTransferFrom(address,address,uint256)", _from, _to, _tokenId)
         );
+    }
+
+    /**
+     * @notice Transfers the ERC20 FNFT fractions
+     *
+     * N.B. Although the Fermion FNFT returns a boolean, as per ERC20 standard, it is not decoded here
+     * since the the return value is not used in the protocol.
+     *
+     * @param _to The address to transfer to.
+     * @param _value The number of fractions to transfer.
+     */
+    function transfer(address _fnft, address _to, uint256 _value) internal {
+        _fnft.functionCallWithAddress(abi.encodeCall(ERC20.transfer, (_to, _value)));
     }
 
     /**

--- a/contracts/test/TestMetaTransactions.sol
+++ b/contracts/test/TestMetaTransactions.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.24;
 
 import { FermionFNFT } from "../protocol/clients/FermionFNFT.sol";
 import { SeaportWrapper } from "../protocol/clients/SeaportWrapper.sol";
+import { FermionFractionsERC20 } from "../protocol/clients/FermionFractionsERC20.sol";
 
 /**
  * @title Test metatransaction _msgData() function
@@ -47,6 +48,18 @@ contract MetaTxTestSeaport is SeaportWrapper {
     ) SeaportWrapper(_bosonPriceDiscovery, _seaportConfig) {
         fermionProtocol = _trustedForwarder;
     }
+
+    function testMsgData(bytes calldata) external {
+        data = msg.data;
+        emit IncomingData(_msgData());
+    }
+}
+
+contract MetaTxTestFractions is FermionFractionsERC20 {
+    event IncomingData(bytes data);
+    bytes public data;
+
+    constructor(address _fermionProtocol) FermionFractionsERC20(_fermionProtocol) {}
 
     function testMsgData(bytes calldata) external {
         data = msg.data;

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -389,7 +389,7 @@ async function getDeploymentData(env: string) {
 
 async function predictFermionDiamondAddress(create3: boolean, transactionOffset: number = 0) {
   if (create3) {
-    // TODO
+    throw Error(`Create3 address calculation is not supported yet.`);
   }
 
   const accounts = await ethers.getSigners();

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -202,33 +202,10 @@ export async function deploySuite(env: string = "", modules: string[] = [], crea
   let facets = {};
 
   if (allModules || modules.includes("facets")) {
-    const nonce = 1n;
-    const nonceHex = ethers.toBeArray(nonce);
-    const input_arr = [diamondAddress, nonceHex];
-    const rlp_encoded = ethers.encodeRlp(input_arr);
-    const contract_address_long = ethers.keccak256(rlp_encoded);
-    const fermionFNFTBeaconAdress = "0x" + contract_address_long.substring(26); //Trim the first 24 characters.
-    const { chainId } = await ethers.provider.getNetwork();
-    const { bytecode: beaconProxyBytecode } = await ethers.getContractFactory("BeaconProxy");
-    const abiCoder = new ethers.AbiCoder();
-    const expectedfermionFNFTBeaconProxy = ethers.getCreate2Address(
-      diamondAddress,
-      ethers.solidityPackedKeccak256(["uint256"], [chainId]),
-      ethers.solidityPackedKeccak256(
-        ["bytes", "bytes"],
-        [beaconProxyBytecode, abiCoder.encode(["address", "bytes"], [fermionFNFTBeaconAdress, "0x"])],
-      ),
-    );
-    const cloneCode = `0x363d3d373d3d3d363d73${expectedfermionFNFTBeaconProxy.slice(2)}5af43d82803e903d91602b57fd5bf3`; // https://eips.ethereum.org/EIPS/eip-1167
-    const fnftCodeHash = ethers.keccak256(cloneCode);
-
     const constructorArgs = {
       MetaTransactionFacet: [diamondAddress],
-      OfferFacet: [bosonProtocolAddress, fnftCodeHash],
-      VerificationFacet: [bosonProtocolAddress, fnftCodeHash, diamondAddress],
-      CustodyFacet: [fnftCodeHash],
-      CustodyVaultFacet: [fnftCodeHash],
-      FundsFacet: [fnftCodeHash],
+      OfferFacet: [bosonProtocolAddress],
+      VerificationFacet: [bosonProtocolAddress, diamondAddress],
     };
     facets = await deployFacets(facetNames, constructorArgs, true);
     await writeContracts(deploymentData, env, version, externalContracts);

--- a/test/clients/fermionFNFT.ts
+++ b/test/clients/fermionFNFT.ts
@@ -39,7 +39,7 @@ describe("FermionFNFT", function () {
     const FermionSeaportWrapper = await ethers.getContractFactory("SeaportWrapper");
     const fermionSeaportWrapper = await FermionSeaportWrapper.deploy(...seaportWrapperConstructorArgs);
     const FermionFractionsERC20 = await ethers.getContractFactory("FermionFractionsERC20");
-    const fermionFractionsERC20Implementation = await FermionFractionsERC20.deploy();
+    const fermionFractionsERC20Implementation = await FermionFractionsERC20.deploy(ZeroAddress);
     const FermionFNFTPriceManager = await ethers.getContractFactory("FermionFNFTPriceManager");
     const fermionFNFTPriceManager = await FermionFNFTPriceManager.deploy();
     const FermionFractionsMint = await ethers.getContractFactory("FermionFractionsMint");

--- a/test/clients/fermionFractions.ts
+++ b/test/clients/fermionFractions.ts
@@ -59,7 +59,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
     const FermionSeaportWrapper = await ethers.getContractFactory("SeaportWrapper");
     const fermionSeaportWrapper = await FermionSeaportWrapper.deploy(...seaportWrapperConstructorArgs);
     const FermionFractionsERC20 = await ethers.getContractFactory("FermionFractionsERC20");
-    const fermionFractionsERC20Implementation = await FermionFractionsERC20.deploy();
+    const fermionFractionsERC20Implementation = await FermionFractionsERC20.deploy(ZeroAddress);
     const FermionFNFTPriceManager = await ethers.getContractFactory("FermionFNFTPriceManager");
     const fermionFNFTPriceManager = await FermionFNFTPriceManager.deploy();
     const FermionFractionsMint = await ethers.getContractFactory("FermionFractionsMint");

--- a/test/clients/fermionWrapper.ts
+++ b/test/clients/fermionWrapper.ts
@@ -51,7 +51,7 @@ describe("FermionFNFT - wrapper tests", function () {
     const FermionFNFTPriceManager = await ethers.getContractFactory("FermionFNFTPriceManager");
     const fermionFNFTPriceManager = await FermionFNFTPriceManager.deploy();
     const FermionFractionsERC20 = await ethers.getContractFactory("FermionFractionsERC20");
-    const fermionFractionsERC20 = await FermionFractionsERC20.deploy();
+    const fermionFractionsERC20 = await FermionFractionsERC20.deploy(ZeroAddress);
     const FermionFractionsMint = await ethers.getContractFactory("FermionFractionsMint");
     const fermionFractionsMint = await FermionFractionsMint.deploy(
       mockBosonPriceDiscovery.address,

--- a/test/protocol/metaTransactionFacet.ts
+++ b/test/protocol/metaTransactionFacet.ts
@@ -1234,7 +1234,6 @@ describe("MetaTransactions", function () {
 
       context("Externally owned account", function () {
         let entity, message;
-        // const tokenId = deriveTokenId(offerId, exchangeId).toString();
         const approval = parseEther("1");
 
         beforeEach(async function () {

--- a/test/protocol/metaTransactionFacet.ts
+++ b/test/protocol/metaTransactionFacet.ts
@@ -1223,7 +1223,11 @@ describe("MetaTransactions", function () {
           newFractionsPerAuction: fractionsAmount * 5n,
         };
 
-        await verificationFacet.submitVerdict(tokenId, VerificationStatus.Verified);
+        const verificationMetadata = {
+          URI: "https://example.com/verification-metadata.json",
+          hash: id("metadata"),
+        };
+        await verificationFacet.submitVerdict(tokenId, VerificationStatus.Verified, verificationMetadata);
         await custodyFacet.checkIn(tokenId);
 
         await fermionFNFT

--- a/test/protocol/metaTransactionFacet.ts
+++ b/test/protocol/metaTransactionFacet.ts
@@ -1457,31 +1457,13 @@ describe("MetaTransactions", function () {
       context("Test msgData", function () {
         let trustedForwarder: HardhatEthersSigner;
         let data: string, dataWithAddress: string;
-        let seaportWrapperConstructorArgs: any[];
 
         beforeEach(async function () {
-          const [mockConduit, mockBosonPriceDiscovery] = wallets.slice(9, 11);
-
-          seaportWrapperConstructorArgs = [
-            mockBosonPriceDiscovery.address,
-            {
-              seaport: wallets[10].address, // dummy address
-              openSeaConduit: mockConduit.address,
-              openSeaConduitKey: ZeroHash,
-              openSeaZoneHash: ZeroHash,
-              openSeaRecipient: ZeroAddress,
-            },
-          ];
-
           trustedForwarder = wallets[1];
         });
 
         it("msg.data includes the sender, _msgData() does not - fermion FNFT", async function () {
-          const FermionSeaportWrapper = await ethers.getContractFactory("SeaportWrapper");
-          fermionSeaportWrapper = await FermionSeaportWrapper.deploy(...seaportWrapperConstructorArgs);
-
           const MetaTxTestFactory = await getContractFactory("MetaTxTestFractions");
-
           const metaTxTest = await MetaTxTestFactory.deploy(trustedForwarder);
 
           data = metaTxTest.interface.encodeFunctionData("testMsgData", ["0xdeadbeef"]);


### PR DESCRIPTION
Close #412 

Fermion protocol can be used as a trusted forwarder for fractions metaTransactions.

To enable it, `_offerId` parameter was changed to `_offerIdWithEpoch`.
When the caller wants to execute metaTx on a ERC20 fractions contract, the input must be constructed as `{epoch+1}{offerId}` where both parts are 128 bits (in bitwise operations: `((epoch+1) << 128n)) | offerId`

The check to see if fermionProtocol is transferring FNFT ERC721 or ERC20 was changed to now rely on `trustedForwarder` getter instead of codehash. Probably checking codehash would still be more efficient, but now we'd need to do it with two hashes (and possible more if some changes are made in the future). This way, it's more legible and more robust.