### PR TITLE
Revert if seaport calls returns false

### DIFF
--- a/contracts/protocol/clients/SeaportWrapper.sol
+++ b/contracts/protocol/clients/SeaportWrapper.sol
@@ -286,7 +286,7 @@ contract SeaportWrapper is FermionFNFTBase {
             });
         }
 
-        SeaportInterface(SEAPORT).validate(orders);
+        if (!SeaportInterface(SEAPORT).validate(orders)) revert WrapperErrors.UnsuccessfulExternalCall();
     }
 
     /**
@@ -309,6 +309,6 @@ contract SeaportWrapper is FermionFNFTBase {
             fixedPrice[tokenId] = 0;
         }
 
-        SeaportInterface(SEAPORT).cancel(_orders);
+        if (!SeaportInterface(SEAPORT).cancel(_orders)) revert WrapperErrors.UnsuccessfulExternalCall();
     }
 }

--- a/contracts/protocol/domain/Errors.sol
+++ b/contracts/protocol/domain/Errors.sol
@@ -195,6 +195,7 @@ interface WrapperErrors {
     error InvalidOwner(uint256 tokenId, address expected, address actual);
     error InvalidUnwrap();
     error InvalidOpenSeaFee(uint256 actual, uint256 expected);
+    error UnsuccessfulExternalCall();
 }
 
 interface FermionErrors is


### PR DESCRIPTION
Close #419 

Not unit tests were added since it's not clear how to make the called functions to successfully execute but return false.