### PR TITLE
Allow multiple price update proposals 

### DIFF
--- a/contracts/protocol/clients/FermionBuyoutAuction.sol
+++ b/contracts/protocol/clients/FermionBuyoutAuction.sol
@@ -169,7 +169,7 @@ contract FermionBuyoutAuction is
         }
 
         auctionDetails.lockedBidAmount = bidAmount;
-        emit Bid(_tokenId, msgSender, _price, totalLockedFractions, bidAmount);
+        emit Bid(_tokenId, msgSender, _price, totalLockedFractions, bidAmount, Common._getFermionFractionsStorage().currentEpoch);
     }
 
     /**
@@ -185,9 +185,8 @@ contract FermionBuyoutAuction is
      * @param _tokenId The token Id
      */
     function removeBid(uint256 _tokenId) external {
-        FermionTypes.BuyoutAuctionStorage storage $ = Common._getBuyoutAuctionStorage(
-            Common._getFermionFractionsStorage().currentEpoch
-        );
+        uint256 currentEpoch = Common._getFermionFractionsStorage().currentEpoch;
+        FermionTypes.BuyoutAuctionStorage storage $ = Common._getBuyoutAuctionStorage(currentEpoch);
         FermionTypes.Auction storage auction = Common.getLastAuction(_tokenId, $);
         FermionTypes.AuctionDetails storage auctionDetails = auction.details;
 
@@ -205,7 +204,7 @@ contract FermionBuyoutAuction is
 
         delete auction.details;
 
-        emit Bid(0, address(0), 0, 0, 0);
+        emit Bid(0, address(0), 0, 0, 0, currentEpoch);
     }
 
     /**
@@ -233,7 +232,7 @@ contract FermionBuyoutAuction is
 
         ERC721._safeTransfer(address(this), msgSender, _tokenId);
 
-        emit Redeemed(_tokenId, msgSender);
+        emit Redeemed(_tokenId, msgSender, Common._getFermionFractionsStorage().currentEpoch);
     }
 
     /**

--- a/contracts/protocol/clients/FermionBuyoutAuction.sol
+++ b/contracts/protocol/clients/FermionBuyoutAuction.sol
@@ -87,89 +87,86 @@ contract FermionBuyoutAuction is
      * @param _fractions The number of fractions to use for the bid, in addition to the fractions already locked during the votes
      */
     function bid(uint256 _tokenId, uint256 _price, uint256 _fractions) external payable {
-        FermionTypes.BuyoutAuctionStorage storage $ = Common._getBuyoutAuctionStorage(
-            Common._getFermionFractionsStorage().currentEpoch
-        );
-        if (!$.tokenInfo[_tokenId].isFractionalised) revert TokenNotFractionalised(_tokenId);
-
-        FermionTypes.Auction storage auction = Common.getLastAuction(_tokenId, $);
-        FermionTypes.AuctionDetails storage auctionDetails = auction.details;
-        if (auctionDetails.state == FermionTypes.AuctionState.Reserved) revert AuctionReserved(_tokenId);
-
-        uint256 minimalBid;
-        {
-            uint256 maxBid = auctionDetails.maxBid;
-            minimalBid = (maxBid * (HUNDRED_PERCENT + MINIMAL_BID_INCREMENT)) / HUNDRED_PERCENT;
-
-            // due to rounding errors, the minimal bid can be equal to the max bid. Ensure strict increase.
-            if (minimalBid == maxBid) minimalBid += 1;
-        }
-
-        if (_price < minimalBid) {
-            revert InvalidBid(_tokenId, _price, minimalBid);
-        }
-
-        uint256 fractionsPerToken;
-        {
-            FermionTypes.BuyoutAuctionParameters storage auctionParameters = $.auctionParameters;
-            if (auctionDetails.state >= FermionTypes.AuctionState.Ongoing) {
-                if (block.timestamp > auctionDetails.timer) revert AuctionEnded(_tokenId, auctionDetails.timer);
-
-                fractionsPerToken = auctionDetails.totalFractions;
-            } else {
-                fractionsPerToken = Common.liquidSupply(Common._getFermionFractionsStorage().currentEpoch) / $.nftCount;
-                if (_price >= auctionParameters.exitPrice && auctionParameters.exitPrice > 0) {
-                    // If price is above the exit price, the cutoff date is set
-                    startAuctionInternal(_tokenId);
-                } else {
-                    // reset ticker for Unbidding
-                    auctionDetails.timer = block.timestamp + auctionParameters.topBidLockTime;
-                }
-            }
-        }
-
-        // Return to the previous bidder the fractions and the bid
-        address exchangeToken = $.exchangeToken;
-        payOutLastBidder(auctionDetails, exchangeToken);
-
-        FermionTypes.Votes storage votes = auction.votes;
-        uint256 availableFractions = fractionsPerToken - votes.total; // available fractions to additionaly be used in bid
-
+        uint256 currentEpoch = Common._getFermionFractionsStorage().currentEpoch;
         address msgSender = _msgSender();
-        uint256 bidAmount;
-        if (_fractions >= availableFractions) {
-            // Bidder has enough fractions to claim the remaining fractions. In this case they win the auction at the current price.
-            // If the locked fractions belong to other users, the bidder must still pay the corresponding price.
-            _fractions = availableFractions;
-
-            if (auctionDetails.state == FermionTypes.AuctionState.NotStarted) startAuctionInternal(_tokenId);
-            auctionDetails.state = FermionTypes.AuctionState.Reserved;
-        }
 
         uint256 totalLockedFractions;
-        unchecked {
-            totalLockedFractions = _fractions + votes.individual[msgSender]; // cannot overflow, since _fractions <= availableFractions = fractionsPerToken - votes.total
-            bidAmount = ((fractionsPerToken - totalLockedFractions) * _price) / fractionsPerToken; // cannot overflow, since fractionsPerToken >= totalLockedFractions
-        }
+        uint256 bidAmount;
+        {
+            FermionTypes.BuyoutAuctionStorage storage $ = Common._getBuyoutAuctionStorage(currentEpoch);
+            if (!$.tokenInfo[_tokenId].isFractionalised) revert TokenNotFractionalised(_tokenId);
 
-        auctionDetails.maxBidder = msgSender;
-        auctionDetails.lockedFractions = _fractions; // locked in addition to the votes. If outbid, this is released back to the bidder
-        auctionDetails.maxBid = _price;
+            FermionTypes.Auction storage auction = Common.getLastAuction(_tokenId, $);
+            FermionTypes.AuctionDetails storage auctionDetails = auction.details;
+            if (auctionDetails.state == FermionTypes.AuctionState.Reserved) revert AuctionReserved(_tokenId);
 
-        if (_fractions > 0) {
-            Common._transferFractions(
-                msgSender,
-                address(this),
-                _fractions,
-                Common._getFermionFractionsStorage().currentEpoch
-            );
-        }
-        if (bidAmount > 0) {
-            validateIncomingPayment(exchangeToken, bidAmount);
-        }
+            uint256 minimalBid;
+            {
+                uint256 maxBid = auctionDetails.maxBid;
+                minimalBid = (maxBid * (HUNDRED_PERCENT + MINIMAL_BID_INCREMENT)) / HUNDRED_PERCENT;
 
-        auctionDetails.lockedBidAmount = bidAmount;
-        emit Bid(_tokenId, msgSender, _price, totalLockedFractions, bidAmount, Common._getFermionFractionsStorage().currentEpoch);
+                // due to rounding errors, the minimal bid can be equal to the max bid. Ensure strict increase.
+                if (minimalBid == maxBid) minimalBid += 1;
+            }
+
+            if (_price < minimalBid) {
+                revert InvalidBid(_tokenId, _price, minimalBid);
+            }
+
+            uint256 fractionsPerToken;
+            {
+                FermionTypes.BuyoutAuctionParameters storage auctionParameters = $.auctionParameters;
+                if (auctionDetails.state >= FermionTypes.AuctionState.Ongoing) {
+                    if (block.timestamp > auctionDetails.timer) revert AuctionEnded(_tokenId, auctionDetails.timer);
+
+                    fractionsPerToken = auctionDetails.totalFractions;
+                } else {
+                    fractionsPerToken = Common.liquidSupply(currentEpoch) / $.nftCount;
+                    if (_price >= auctionParameters.exitPrice && auctionParameters.exitPrice > 0) {
+                        // If price is above the exit price, the cutoff date is set
+                        startAuctionInternal(_tokenId);
+                    } else {
+                        // reset ticker for Unbidding
+                        auctionDetails.timer = block.timestamp + auctionParameters.topBidLockTime;
+                    }
+                }
+            }
+
+            // Return to the previous bidder the fractions and the bid
+            address exchangeToken = $.exchangeToken;
+            payOutLastBidder(auctionDetails, exchangeToken);
+
+            FermionTypes.Votes storage votes = auction.votes;
+            uint256 availableFractions = fractionsPerToken - votes.total; // available fractions to additionaly be used in bid
+
+            if (_fractions >= availableFractions) {
+                // Bidder has enough fractions to claim the remaining fractions. In this case they win the auction at the current price.
+                // If the locked fractions belong to other users, the bidder must still pay the corresponding price.
+                _fractions = availableFractions;
+
+                if (auctionDetails.state == FermionTypes.AuctionState.NotStarted) startAuctionInternal(_tokenId);
+                auctionDetails.state = FermionTypes.AuctionState.Reserved;
+            }
+
+            unchecked {
+                totalLockedFractions = _fractions + votes.individual[msgSender]; // cannot overflow, since _fractions <= availableFractions = fractionsPerToken - votes.total
+                bidAmount = ((fractionsPerToken - totalLockedFractions) * _price) / fractionsPerToken; // cannot overflow, since fractionsPerToken >= totalLockedFractions
+            }
+
+            auctionDetails.maxBidder = msgSender;
+            auctionDetails.lockedFractions = _fractions; // locked in addition to the votes. If outbid, this is released back to the bidder
+            auctionDetails.maxBid = _price;
+
+            if (_fractions > 0) {
+                Common._transferFractions(msgSender, address(this), _fractions, currentEpoch);
+            }
+            if (bidAmount > 0) {
+                validateIncomingPayment(exchangeToken, bidAmount);
+            }
+
+            auctionDetails.lockedBidAmount = bidAmount;
+        }
+        emit Bid(_tokenId, msgSender, _price, totalLockedFractions, bidAmount, currentEpoch);
     }
 
     /**

--- a/contracts/protocol/clients/FermionFNFTPriceManager.sol
+++ b/contracts/protocol/clients/FermionFNFTPriceManager.sol
@@ -140,12 +140,7 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
             votes.total -= _fractionAmount;
         }
 
-        Common._transferFractions(
-            address(this),
-            msgSender,
-            _fractionAmount,
-            currentEpoch
-        );
+        Common._transferFractions(address(this), msgSender, _fractionAmount, currentEpoch);
 
         emit IFermionFractionsEvents.VoteRemoved(_tokenId, msgSender, _fractionAmount, currentEpoch);
     }
@@ -292,7 +287,13 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
 
             $.voters[msgSender] = voter;
 
-            emit IFermionFractionsEvents.PriceUpdateVoted(_proposalId, msgSender, fractionsBalance, _voteYes, currentEpoch);
+            emit IFermionFractionsEvents.PriceUpdateVoted(
+                _proposalId,
+                msgSender,
+                fractionsBalance,
+                _voteYes,
+                currentEpoch
+            );
         }
     }
 
@@ -337,7 +338,13 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
 
         delete $.voters[msgSender];
 
-        emit IFermionFractionsEvents.PriceUpdateVoteRemoved(_proposalId, msgSender, votesToRemove, votedYes, currentEpoch);
+        emit IFermionFractionsEvents.PriceUpdateVoteRemoved(
+            _proposalId,
+            msgSender,
+            votesToRemove,
+            votedYes,
+            currentEpoch
+        );
     }
 
     /**
@@ -367,10 +374,7 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
         if (totalVotes >= quorumRequired) {
             if (_proposal.yesVotes > _proposal.noVotes) {
                 _proposal.state = FermionTypes.PriceUpdateProposalState.Executed;
-                Common
-                    ._getBuyoutAuctionStorage(currentEpoch)
-                    .auctionParameters
-                    .exitPrice = _proposal.newExitPrice;
+                Common._getBuyoutAuctionStorage(currentEpoch).auctionParameters.exitPrice = _proposal.newExitPrice;
                 emit IFermionFractionsEvents.ExitPriceUpdated(_proposal.newExitPrice, false, currentEpoch);
             } else {
                 _proposal.state = FermionTypes.PriceUpdateProposalState.Failed;
@@ -461,6 +465,12 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
                 proposal.noVotes -= votesToRemove;
             }
         }
-        emit IFermionFractionsEvents.PriceUpdateVoteRemoved(voterProposalId, from, votesToRemove, voter.votedYes, currentEpoch);
+        emit IFermionFractionsEvents.PriceUpdateVoteRemoved(
+            voterProposalId,
+            from,
+            votesToRemove,
+            voter.votedYes,
+            currentEpoch
+        );
     }
 }

--- a/contracts/protocol/clients/FermionFNFTPriceManager.sol
+++ b/contracts/protocol/clients/FermionFNFTPriceManager.sol
@@ -197,9 +197,11 @@ contract FermionFNFTPriceManager is FermionErrors, ERC2771Context, IFermionFNFTP
             revert FractionalisationErrors.OnlyFractionOwner();
         }
 
-        if (voter.proposalId < $.priceUpdateProposals.length) {
-            if ($.priceUpdateProposals[voter.proposalId].state == FermionTypes.PriceUpdateProposalState.Active)
-                revert FractionalisationErrors.AlreadyVotedInProposal(voter.proposalId);
+        if (
+            voter.voteCount != 0 &&
+            $.priceUpdateProposals[voter.proposalId].state == FermionTypes.PriceUpdateProposalState.Active
+        ) {
+            revert FractionalisationErrors.AlreadyVotedInProposal(voter.proposalId);
         }
 
         if (_quorumPercent < MIN_QUORUM_PERCENT || _quorumPercent > HUNDRED_PERCENT) {

--- a/contracts/protocol/clients/FermionFractions.sol
+++ b/contracts/protocol/clients/FermionFractions.sol
@@ -379,8 +379,9 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
      * - `AlreadyVoted` if the caller has already voted and has no additional fractions to contribute.
      *
      * @param _voteYes True to vote YES, false to vote NO.
+     * @param _proposalId The ID of the proposal to vote on.
      */
-    function voteOnProposal(bool _voteYes) external {
+    function voteOnProposal(bool _voteYes, uint256 _proposalId) external {
         forwardCall(FNFT_PRICE_MANAGER);
     }
 
@@ -396,8 +397,9 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
      * - `ProposalNotActive` if the proposal is not active.
      * - `NoVotingPower` if the caller has no votes recorded on the active proposal.
      *
+     * @param _proposalId The ID of the proposal to remove the vote from.
      */
-    function removeVoteOnProposal() external {
+    function removeVoteOnProposal(uint256 _proposalId) external {
         forwardCall(FNFT_PRICE_MANAGER);
     }
 
@@ -531,7 +533,7 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
     }
 
     /**
-     * @notice Returns the non-mapping details of the current active proposal.
+     * @notice Returns details of a specific proposal from current epoch.
      *
      * @return proposalId The unique ID of the proposal.
      * @return newExitPrice The proposed exit price.
@@ -541,7 +543,9 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
      * @return noVotes The number of votes against.
      * @return state The state of the proposal (Active, Executed, or Failed).
      */
-    function getCurrentProposalDetails()
+    function getProposalDetails(
+        uint256 _proposalId
+    )
         external
         view
         returns (
@@ -556,7 +560,7 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
     {
         FermionTypes.PriceUpdateProposal storage proposal = Common
             ._getBuyoutAuctionStorage(Common._getFermionFractionsStorage().currentEpoch)
-            .currentProposal;
+            .priceUpdateProposals[_proposalId];
         return (
             proposal.proposalId,
             proposal.newExitPrice,
@@ -575,10 +579,7 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
      * @return voterDetails The details of the voter's vote.
      */
     function getVoterDetails(address _voter) external view returns (FermionTypes.PriceUpdateVoter memory) {
-        return
-            Common._getBuyoutAuctionStorage(Common._getFermionFractionsStorage().currentEpoch).currentProposal.voters[
-                _voter
-            ];
+        return Common._getBuyoutAuctionStorage(Common._getFermionFractionsStorage().currentEpoch).voters[_voter];
     }
 
     /**

--- a/contracts/protocol/clients/FermionFractions.sol
+++ b/contracts/protocol/clients/FermionFractions.sol
@@ -378,10 +378,10 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
      * - `ConflictingVote` if the caller attempts to vote differently from their previous vote.
      * - `AlreadyVoted` if the caller has already voted and has no additional fractions to contribute.
      *
-     * @param _voteYes True to vote YES, false to vote NO.
      * @param _proposalId The ID of the proposal to vote on.
+     * @param _voteYes True to vote YES, false to vote NO.
      */
-    function voteOnProposal(bool _voteYes, uint256 _proposalId) external {
+    function voteOnProposal(uint256 _proposalId, bool _voteYes) external {
         forwardCall(FNFT_PRICE_MANAGER);
     }
 
@@ -535,7 +535,6 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
     /**
      * @notice Returns details of a specific proposal from current epoch.
      *
-     * @return proposalId The unique ID of the proposal.
      * @return newExitPrice The proposed exit price.
      * @return votingDeadline The deadline for voting.
      * @return quorumPercent The required quorum percentage.
@@ -549,7 +548,6 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
         external
         view
         returns (
-            uint256 proposalId,
             uint256 newExitPrice,
             uint256 votingDeadline,
             uint256 quorumPercent,
@@ -562,7 +560,6 @@ abstract contract FermionFractions is FermionErrors, IFermionFractions {
             ._getBuyoutAuctionStorage(Common._getFermionFractionsStorage().currentEpoch)
             .priceUpdateProposals[_proposalId];
         return (
-            proposal.proposalId,
             proposal.newExitPrice,
             proposal.votingDeadline,
             proposal.quorumPercent,

--- a/contracts/protocol/clients/FermionFractionsERC20.sol
+++ b/contracts/protocol/clients/FermionFractionsERC20.sol
@@ -57,12 +57,12 @@ contract FermionFractionsERC20 is Initializable, ERC20PermitUpgradeable, ERC2771
     /**
      * @dev Override the _update function to notify the owner (FermionFNFT contract) about transfers.
      * This allows the FermionFNFT contract to adjust votes when necessary to maintain voting integrity.
-     * The notification is only sent for actual transfers (not mints or burns).
+     * The notifications is only sent for transfers and burns (excluding mints as they have no effect on voting power adjustments).
      */
     function _update(address from, address to, uint256 value) internal override {
         super._update(from, to, value);
 
-        if (from != address(0) && to != address(0)) {
+        if (from != address(0)) {
             IFermionFNFTPriceManager(owner()).adjustVotesOnTransfer(from, value);
         }
     }

--- a/contracts/protocol/clients/FermionFractionsMint.sol
+++ b/contracts/protocol/clients/FermionFractionsMint.sol
@@ -320,10 +320,7 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
             emit Fractionalised(tokenId, _fractionsAmount, currentEpoch);
         }
 
-        FermionFractionsERC20(fractionStorage.epochToClone[currentEpoch]).mint(
-            tokenOwner,
-            _length * _fractionsAmount
-        );
+        FermionFractionsERC20(fractionStorage.epochToClone[currentEpoch]).mint(tokenOwner, _length * _fractionsAmount);
 
         $.nftCount += _length;
     }

--- a/contracts/protocol/clients/FermionFractionsMint.sol
+++ b/contracts/protocol/clients/FermionFractionsMint.sol
@@ -135,7 +135,7 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
 
         $.auctionParameters = _buyoutAuctionParameters;
 
-        emit FractionsSetup(_fractionsAmount, _buyoutAuctionParameters);
+        emit FractionsSetup(_fractionsAmount, _buyoutAuctionParameters, currentEpoch);
 
         address msgSender = _msgSender();
         if (msgSender != FERMION_PROTOCOL) {
@@ -219,7 +219,7 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
 
         FermionFractionsERC20(fractionStorage.epochToClone[currentEpoch]).mint(FERMION_PROTOCOL, _amount);
 
-        emit AdditionalFractionsMinted(_amount, Common.liquidSupply(currentEpoch));
+        emit AdditionalFractionsMinted(_amount, Common.liquidSupply(currentEpoch), currentEpoch);
     }
 
     /**
@@ -297,7 +297,8 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
         FermionTypes.BuyoutAuctionStorage storage $
     ) internal {
         address tokenOwner = ownerOf(_firstTokenId); // all tokens must be owned by the same address
-
+        FermionTypes.FermionFractionsStorage storage fractionStorage = Common._getFermionFractionsStorage();
+        uint256 currentEpoch = fractionStorage.currentEpoch;
         for (uint256 i = 0; i < _length; i++) {
             uint256 tokenId = _firstTokenId + i;
             FermionTypes.TokenState tokenState = Common._getFermionCommonStorage().tokenState[tokenId];
@@ -316,12 +317,10 @@ contract FermionFractionsMint is FermionFNFTBase, FermionErrors, FundsManager, I
             tokenInfo.isFractionalised = true;
             tokenInfo.auctions.push();
 
-            emit Fractionalised(tokenId, _fractionsAmount);
+            emit Fractionalised(tokenId, _fractionsAmount, currentEpoch);
         }
 
-        FermionTypes.FermionFractionsStorage storage fractionStorage = Common._getFermionFractionsStorage();
-
-        FermionFractionsERC20(fractionStorage.epochToClone[fractionStorage.currentEpoch]).mint(
+        FermionFractionsERC20(fractionStorage.epochToClone[currentEpoch]).mint(
             tokenOwner,
             _length * _fractionsAmount
         );

--- a/contracts/protocol/domain/Errors.sol
+++ b/contracts/protocol/domain/Errors.sol
@@ -175,6 +175,7 @@ interface FractionalisationErrors is AuctionErrors {
     error OnlyFractionOwner();
     error InvalidVoteDuration(uint256 voteDuration);
     error AlreadyVotedInProposal(uint256 proposalId);
+    error InvalidProposalId();
     error ConflictingVote();
     error OracleInternalError();
     error AlreadyMigrated(address owner);

--- a/contracts/protocol/domain/Errors.sol
+++ b/contracts/protocol/domain/Errors.sol
@@ -174,7 +174,7 @@ interface FractionalisationErrors is AuctionErrors {
     error NoVotingPower(address voter);
     error OnlyFractionOwner();
     error InvalidVoteDuration(uint256 voteDuration);
-    error OngoingProposalExists();
+    error AlreadyVotedInProposal(uint256 proposalId);
     error ConflictingVote();
     error OracleInternalError();
     error AlreadyMigrated(address owner);

--- a/contracts/protocol/domain/Types.sol
+++ b/contracts/protocol/domain/Types.sol
@@ -177,7 +177,8 @@ contract FermionTypes {
         uint256 lockedRedeemableSupply;
         mapping(uint256 => TokenAuctionInfo) tokenInfo;
         address priceOracle;
-        PriceUpdateProposal currentProposal; // Stores the single active proposal
+        mapping(address => PriceUpdateVoter) voters;
+        PriceUpdateProposal[] priceUpdateProposals;
     }
 
     struct TokenAuctionInfo {
@@ -209,7 +210,6 @@ contract FermionTypes {
         uint256 yesVotes;
         uint256 noVotes;
         PriceUpdateProposalState state;
-        mapping(address => PriceUpdateVoter) voters;
     }
 
     struct PriceUpdateVoter {

--- a/contracts/protocol/domain/Types.sol
+++ b/contracts/protocol/domain/Types.sol
@@ -203,7 +203,6 @@ contract FermionTypes {
     }
 
     struct PriceUpdateProposal {
-        uint256 proposalId; // Tracks the ID of the current proposal
         uint256 newExitPrice;
         uint256 votingDeadline;
         uint256 quorumPercent; // in bps (e.g. 2000 is 20%)

--- a/contracts/protocol/interfaces/IFermionFNFTPriceManager.sol
+++ b/contracts/protocol/interfaces/IFermionFNFTPriceManager.sol
@@ -35,8 +35,9 @@ interface IFermionFNFTPriceManager {
      * - `AlreadyVoted` if the caller has already voted and has no additional fractions to contribute.
      *
      * @param voteYes True to vote YES, false to vote NO.
+     * @param _proposalId The ID of the proposal to vote on.
      */
-    function voteOnProposal(bool voteYes) external;
+    function voteOnProposal(bool voteYes, uint256 _proposalId) external;
 
     /**
      * @notice Allows a voter to explicitly remove their vote on an active proposal.
@@ -47,8 +48,10 @@ interface IFermionFNFTPriceManager {
      * Reverts:
      * - `ProposalNotActive` if the proposal is not active.
      * - `NoVotingPower` if the caller has no votes recorded on the active proposal.
+     *
+     * @param _proposalId The ID of the proposal to remove the vote from.
      */
-    function removeVoteOnProposal() external;
+    function removeVoteOnProposal(uint256 _proposalId) external;
 
     /**
      * @notice Fractional owners can vote to start the auction for a specific token, even if the current bid is below the exit price.

--- a/contracts/protocol/interfaces/IFermionFNFTPriceManager.sol
+++ b/contracts/protocol/interfaces/IFermionFNFTPriceManager.sol
@@ -34,10 +34,10 @@ interface IFermionFNFTPriceManager {
      * - `ConflictingVote` if the caller attempts to vote differently from their previous vote.
      * - `AlreadyVoted` if the caller has already voted and has no additional fractions to contribute.
      *
-     * @param voteYes True to vote YES, false to vote NO.
      * @param _proposalId The ID of the proposal to vote on.
+     * @param voteYes True to vote YES, false to vote NO.
      */
-    function voteOnProposal(bool voteYes, uint256 _proposalId) external;
+    function voteOnProposal(uint256 _proposalId, bool voteYes) external;
 
     /**
      * @notice Allows a voter to explicitly remove their vote on an active proposal.

--- a/contracts/protocol/interfaces/events/IFermionFractionsEvents.sol
+++ b/contracts/protocol/interfaces/events/IFermionFractionsEvents.sol
@@ -23,7 +23,11 @@ interface IFermionFractionsEvents {
     event VoteRemoved(uint256 indexed tokenId, address indexed from, uint256 fractionAmount, uint256 epoch);
     event AuctionStarted(uint256 indexed tokenId, uint256 endTime, uint256 epoch);
     event Fractionalised(uint256 indexed tokenId, uint256 fractionsCount, uint256 epoch);
-    event FractionsSetup(uint256 initialFractionsAmount, FermionTypes.BuyoutAuctionParameters buyoutAuctionParameters, uint256 epoch);
+    event FractionsSetup(
+        uint256 initialFractionsAmount,
+        FermionTypes.BuyoutAuctionParameters buyoutAuctionParameters,
+        uint256 epoch
+    );
     event AdditionalFractionsMinted(uint256 additionalAmount, uint256 totalFractionsAmount, uint256 epoch);
     // Buyout Exit Price Governance Update Events
     event PriceUpdateProposalCreated(
@@ -31,10 +35,16 @@ interface IFermionFractionsEvents {
         uint256 newExitPrice,
         uint256 votingDeadline,
         uint256 quorumRequired,
-        uint256 epoch   
+        uint256 epoch
     );
     event PriceUpdateProposalFinalized(uint256 indexed proposalId, bool success, uint256 epoch);
-    event PriceUpdateVoted(uint256 indexed proposalId, address indexed voter, uint256 voteCount, bool votedYes, uint256 epoch);
+    event PriceUpdateVoted(
+        uint256 indexed proposalId,
+        address indexed voter,
+        uint256 voteCount,
+        bool votedYes,
+        uint256 epoch
+    );
     event PriceUpdateVoteRemoved(
         uint256 indexed proposalId,
         address indexed voter,

--- a/contracts/protocol/interfaces/events/IFermionFractionsEvents.sol
+++ b/contracts/protocol/interfaces/events/IFermionFractionsEvents.sol
@@ -14,31 +14,34 @@ interface IFermionFractionsEvents {
         address indexed from,
         uint256 newPrice,
         uint256 fractionsCount,
-        uint256 bidAmount
+        uint256 bidAmount,
+        uint256 epoch
     );
-    event Redeemed(uint256 indexed tokenId, address indexed from);
+    event Redeemed(uint256 indexed tokenId, address indexed from, uint256 epoch);
     event Claimed(address indexed from, uint256 fractionsBurned, uint256 amountClaimed, uint256 epoch);
-    event Voted(uint256 indexed tokenId, address indexed from, uint256 fractionAmount);
-    event VoteRemoved(uint256 indexed tokenId, address indexed from, uint256 fractionAmount);
+    event Voted(uint256 indexed tokenId, address indexed from, uint256 fractionAmount, uint256 epoch);
+    event VoteRemoved(uint256 indexed tokenId, address indexed from, uint256 fractionAmount, uint256 epoch);
     event AuctionStarted(uint256 indexed tokenId, uint256 endTime, uint256 epoch);
-    event Fractionalised(uint256 indexed tokenId, uint256 fractionsCount);
-    event FractionsSetup(uint256 initialFractionsAmount, FermionTypes.BuyoutAuctionParameters buyoutAuctionParameters);
-    event AdditionalFractionsMinted(uint256 additionalAmount, uint256 totalFractionsAmount);
+    event Fractionalised(uint256 indexed tokenId, uint256 fractionsCount, uint256 epoch);
+    event FractionsSetup(uint256 initialFractionsAmount, FermionTypes.BuyoutAuctionParameters buyoutAuctionParameters, uint256 epoch);
+    event AdditionalFractionsMinted(uint256 additionalAmount, uint256 totalFractionsAmount, uint256 epoch);
     // Buyout Exit Price Governance Update Events
     event PriceUpdateProposalCreated(
         uint256 indexed proposalId,
         uint256 newExitPrice,
         uint256 votingDeadline,
-        uint256 quorumRequired
+        uint256 quorumRequired,
+        uint256 epoch   
     );
-    event PriceUpdateProposalFinalized(uint256 indexed proposalId, bool success);
-    event PriceUpdateVoted(uint256 indexed proposalId, address indexed voter, uint256 voteCount, bool votedYes);
+    event PriceUpdateProposalFinalized(uint256 indexed proposalId, bool success, uint256 epoch);
+    event PriceUpdateVoted(uint256 indexed proposalId, address indexed voter, uint256 voteCount, bool votedYes, uint256 epoch);
     event PriceUpdateVoteRemoved(
         uint256 indexed proposalId,
         address indexed voter,
         uint256 votesRemoved,
-        bool votedYes
+        bool votedYes,
+        uint256 epoch
     );
-    event ExitPriceUpdated(uint256 newPrice, bool isOracleUpdate);
+    event ExitPriceUpdated(uint256 newPrice, bool isOracleUpdate, uint256 epoch);
     event FractionsMigrated(address owners, uint256 fractionBalance);
 }

--- a/test/clients/fermionFractions.ts
+++ b/test/clients/fermionFractions.ts
@@ -250,9 +250,9 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx)
         .to.emit(fermionFNFTProxy, "FractionsSetup")
-        .withArgs(fractionsAmount, Object.values(auctionParameters));
+        .withArgs(fractionsAmount, Object.values(auctionParameters), 0);
 
-      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsAmount);
+      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsAmount, 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId)).to.equal(await fermionFNFTProxy.getAddress());
@@ -293,7 +293,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           .to.emit(fermionFNFTProxy, "Transfer")
           .withArgs(seller.address, await fermionFNFTProxy.getAddress(), tokenId);
 
-        await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(tokenId, fractionsAmount);
+        await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(tokenId, fractionsAmount, 0);
       }
       // mint fractions (erc20 mint)
       await expect(tx)
@@ -302,7 +302,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx)
         .to.emit(fermionFNFTProxy, "FractionsSetup")
-        .withArgs(fractionsAmount, Object.values(auctionParameters));
+        .withArgs(fractionsAmount, Object.values(auctionParameters), 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId)).to.equal(await fermionFNFTProxy.getAddress());
@@ -343,7 +343,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx)
         .to.emit(fermionFNFTProxy, "FractionsSetup")
-        .withArgs(fractionsAmount, Object.values(auctionDefaultParameters));
+        .withArgs(fractionsAmount, Object.values(auctionDefaultParameters), 0);
 
       // state
       expect(await fermionFNFTProxy.getBuyoutAuctionParameters(0)).to.eql(Object.values(auctionDefaultParameters));
@@ -374,9 +374,9 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx)
         .to.emit(fermionFNFTProxy, "FractionsSetup")
-        .withArgs(fractionsAmount, Object.values(auctionParameters));
+        .withArgs(fractionsAmount, Object.values(auctionParameters), 0);
 
-      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsAmount);
+      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsAmount, 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId)).to.equal(await fermionFNFTProxy.getAddress());
@@ -780,7 +780,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx).to.not.emit(fermionFNFTProxy, "FractionsSetup");
 
-      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount);
+      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount, 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId2)).to.equal(await fermionFNFTProxy.getAddress());
@@ -802,7 +802,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           .to.emit(fermionFNFTProxy, "Transfer")
           .withArgs(seller.address, await fermionFNFTProxy.getAddress(), tokenId);
 
-        await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(tokenId, fractionsAmount);
+        await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(tokenId, fractionsAmount, 0);
       }
 
       // mint fractions (erc20 mint)
@@ -835,7 +835,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx).to.not.emit(fermionFNFTProxy, "FractionsSetup");
 
-      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount);
+      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount, 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId2)).to.equal(await fermionFNFTProxy.getAddress());
@@ -864,7 +864,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       await expect(tx).to.not.emit(fermionFNFTProxy, "FractionsSetup");
 
-      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount);
+      await expect(tx).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId2, fractionsAmount, 0);
 
       // state
       expect(await fermionFNFTProxy.ownerOf(startTokenId2)).to.equal(await fermionFNFTProxy.getAddress());
@@ -973,7 +973,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       // lock the F-NFT (erc721 transfer)
       await expect(tx)
         .to.emit(fermionFNFTProxy, "AdditionalFractionsMinted")
-        .withArgs(additionalAmount, additionalAmount + fractionsAmount);
+        .withArgs(additionalAmount, additionalAmount + fractionsAmount, 0);
 
       // mint fractions (erc20 mint)
       await expect(tx)
@@ -1199,7 +1199,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1229,7 +1229,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1259,7 +1259,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, bidAmount, fractions, bidAmount, 0);
         await expect(tx).to.not.emit(fermionFNFTProxy, "AuctionStarted");
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
@@ -1390,7 +1390,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractions, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractions, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1424,7 +1424,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractions, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractions, bidAmount, 0);
         await expect(tx).to.not.emit(fermionFNFTProxy, "AuctionStarted");
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
@@ -1506,7 +1506,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractionsPart, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractionsPart, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1544,7 +1544,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1590,7 +1590,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, votes, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, votes, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1624,7 +1624,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, votes, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, votes, bidAmount, 0);
         await expect(tx).to.not.emit(fermionFNFTProxy, "AuctionStarted");
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
@@ -1715,7 +1715,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractions + votes, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractions + votes, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1749,7 +1749,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractions + votes, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractions + votes, bidAmount, 0);
         await expect(tx).to.not.emit(fermionFNFTProxy, "AuctionStarted");
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
@@ -1837,7 +1837,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractionsPart + votes, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractionsPart + votes, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1878,7 +1878,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -1917,7 +1917,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "Bid")
-          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount);
+          .withArgs(startTokenId, bidders[0].address, price, fractionsPerToken, bidAmount, 0);
 
         const blockTimeStamp = (await tx.getBlock()).timestamp;
         const auctionEnd = BigInt(blockTimeStamp) + auctionParameters.duration;
@@ -2121,7 +2121,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         await expect(tx2)
           .to.emit(mockExchangeToken, "Transfer")
           .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, bidAmount);
-        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n, 0);
 
         // state
         expect(await fermionFNFTProxy.getAuctionDetails(startTokenId)).to.eql(Object.values(expectedAuctionDetails));
@@ -2156,7 +2156,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         await expect(tx2)
           .to.emit(await getERC20Clone(fermionFNFTProxy), "Transfer")
           .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, fractions);
-        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n, 0);
 
         expect(await mockExchangeToken.balanceOf(bidders[0].address)).to.equal(parseEther("1000"));
         expect(await mockExchangeToken.balanceOf(await fermionFNFTProxy.getAddress())).to.equal(0n);
@@ -2192,7 +2192,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         await expect(tx2)
           .to.emit(mockExchangeToken, "Transfer")
           .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, bidAmount);
-        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Bid").withArgs(0, ZeroAddress, 0n, 0n, 0n, 0);
 
         expect(await mockExchangeToken.balanceOf(bidders[0].address)).to.equal(parseEther("1000"));
         expect(await mockExchangeToken.balanceOf(await fermionFNFTProxy.getAddress())).to.equal(0n);
@@ -2355,7 +2355,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       await setNextBlockTimestamp(String(auctionEnd + 1n));
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       await expect(tx2)
         .to.emit(fermionFNFTProxy, "Transfer")
         .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, startTokenId);
@@ -2382,7 +2382,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       await setNextBlockTimestamp(String(auctionEnd + 1n));
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       await expect(tx2)
         .to.emit(fermionFNFTProxy, "Transfer")
         .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, startTokenId);
@@ -2419,7 +2419,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       await setNextBlockTimestamp(String(auctionEnd + 1n));
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       await expect(tx2)
         .to.emit(fermionFNFTProxy, "Transfer")
         .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, startTokenId);
@@ -2457,7 +2457,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
       expect(await fermionFNFTProxy.balanceOf(bidders[0].address)).to.equal(1n);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       await expect(tx2)
         .to.emit(fermionFNFTProxy, "Transfer")
         .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, startTokenId);
@@ -2489,7 +2489,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       await setNextBlockTimestamp(String(auctionEnd + 1n));
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       await expect(tx2)
         .to.emit(fermionFNFTProxy, "Transfer")
         .withArgs(await fermionFNFTProxy.getAddress(), bidders[0].address, startTokenId);
@@ -2524,14 +2524,14 @@ describe("FermionFNFT - fractionalisation tests", function () {
         await fermionFNFTProxy.connect(seller).claimWithLockedFractions(startTokenId, 0, fractionsPerToken);
 
         const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-        await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       });
 
       it("Via finalizeAndClaim", async function () {
         await fermionFNFTProxy.connect(seller).finalizeAndClaim(startTokenId, fractionsPerToken);
 
         const tx2 = await fermionFNFTProxy.connect(bidders[0]).redeem(startTokenId);
-        await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Redeemed").withArgs(startTokenId, bidders[0].address, 0);
       });
     });
 
@@ -3339,7 +3339,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       ).to.be.revertedWithCustomError(fermionFNFTProxy, "InitialFractionalisationOnly");
 
       const tx2 = await fermionFNFTProxy.connect(bidders[0]).mintFractions(startTokenId, 1, additionalDeposit);
-      await expect(tx2).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsPerToken);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsPerToken, 0);
 
       // state
       // current auction should not exists
@@ -3446,7 +3446,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           additionalDeposit,
           ZeroAddress,
         );
-      await expect(tx2).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsPerToken2);
+      await expect(tx2).to.emit(fermionFNFTProxy, "Fractionalised").withArgs(startTokenId, fractionsPerToken2, 1);
 
       expect(await fermionFNFTProxy.getBuyoutAuctionParameters(1)).to.eql(Object.values(auctionParameters2));
 
@@ -3617,7 +3617,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
       it("The fractional owner can vote to start the auction", async function () {
         const tx = await fermionFNFTProxy.connect(bidders[0]).voteToStartAuction(startTokenId, votes1);
 
-        await expect(tx).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, votes1);
+        await expect(tx).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, votes1, 0);
         await expect(tx).to.not.emit(fermionFNFTProxy, "AuctionStarted");
 
         // state
@@ -3634,7 +3634,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         const firstVote = (votes1 * 20n) / 100n;
         const tx = await fermionFNFTProxy.connect(bidders[0]).voteToStartAuction(startTokenId, firstVote);
 
-        await expect(tx).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, firstVote);
+        await expect(tx).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, firstVote, 0);
 
         // state
         const [totalVotes, threshold, availableFractions] = await fermionFNFTProxy.getVotes(startTokenId);
@@ -3648,7 +3648,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         const secondVote = votes1 - firstVote;
         const tx2 = await fermionFNFTProxy.connect(bidders[0]).voteToStartAuction(startTokenId, secondVote);
 
-        await expect(tx2).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, secondVote);
+        await expect(tx2).to.emit(fermionFNFTProxy, "Voted").withArgs(startTokenId, bidders[0].address, secondVote, 0);
 
         // state
         const [totalVotes2, threshold2, availableFractions2] = await fermionFNFTProxy.getVotes(startTokenId);
@@ -3732,7 +3732,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(fermionFNFTProxy.connect(bidders[1]).voteToStartAuction(startTokenId, votes2))
           .to.emit(fermionFNFTProxy, "Voted")
-          .withArgs(startTokenId, bidders[1].address, votes2);
+          .withArgs(startTokenId, bidders[1].address, votes2, 0);
       });
 
       context("Revert reasons", function () {
@@ -3831,7 +3831,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "VoteRemoved")
-          .withArgs(startTokenId, bidders[0].address, votesToRemove);
+          .withArgs(startTokenId, bidders[0].address, votesToRemove, 0);
 
         // state
         const [totalVotes, threshold, availableFractions] = await fermionFNFTProxy.getVotes(startTokenId);
@@ -3852,14 +3852,14 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "VoteRemoved")
-          .withArgs(startTokenId, bidders[0].address, votesToRemove);
+          .withArgs(startTokenId, bidders[0].address, votesToRemove, 0);
 
         const remainder = votes1 - votesToRemove;
         const tx2 = await fermionFNFTProxy.connect(bidders[0]).removeVoteToStartAuction(startTokenId, remainder);
 
         await expect(tx2)
           .to.emit(fermionFNFTProxy, "VoteRemoved")
-          .withArgs(startTokenId, bidders[0].address, remainder);
+          .withArgs(startTokenId, bidders[0].address, remainder, 0);
 
         // state
         const [totalVotes2, threshold2, availableFractions2] = await fermionFNFTProxy.getVotes(startTokenId);
@@ -3979,7 +3979,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         await mockOracle.enableOtherErrorRevert(false);
         await expect(fermionFNFTProxy.updateExitPrice(0, 7500, MIN_GOV_VOTE_DURATION))
           .to.emit(fermionFNFTProxy, "ExitPriceUpdated")
-          .withArgs(parseEther("2.5"), true);
+          .withArgs(parseEther("2.5"), true, 0);
       });
 
       it("should revert if oracle returns a different error", async function () {
@@ -3999,7 +3999,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "PriceUpdateProposalCreated")
-          .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500);
+          .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500, 0);
       });
 
       it("should fallback to governance if oracle is not whitelisted in registry", async function () {
@@ -4013,7 +4013,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
         await expect(tx)
           .to.emit(fermionFNFTProxy, "PriceUpdateProposalCreated")
-          .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500);
+          .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500, 0);
       });
     });
 
@@ -4040,7 +4040,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           await expect(tx)
             .to.emit(fermionFNFTProxy, "PriceUpdateProposalCreated")
-            .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500);
+            .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500, 0);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.newExitPrice).to.equal(parseEther("2"));
@@ -4055,7 +4055,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           await expect(tx)
             .to.emit(fermionFNFTProxy, "PriceUpdateProposalCreated")
-            .withArgs(0, parseEther("2"), blockTimestamp + DEFAULT_GOV_VOTE_DURATION, 7500);
+            .withArgs(0, parseEther("2"), blockTimestamp + DEFAULT_GOV_VOTE_DURATION, 7500, 0);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.newExitPrice).to.equal(parseEther("2"));
@@ -4389,7 +4389,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // Verify emitted event
             await expect(tx)
               .to.emit(fermionFNFTProxy, "PriceUpdateVoteRemoved")
-              .withArgs(0, owner1.address, owner1Balance, false);
+              .withArgs(0, owner1.address, owner1Balance, false, 0);
 
             // Step 4: Verify the proposal state after vote removal
             proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4415,7 +4415,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // Verify emitted event
             await expect(tx)
               .to.emit(fermionFNFTProxy, "PriceUpdateVoteRemoved")
-              .withArgs(0, owner1.address, owner1Balance, true);
+              .withArgs(0, owner1.address, owner1Balance, true, 0);
 
             // Step 3: Verify the proposal state after vote removal
             proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4459,9 +4459,9 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           await expect(tx)
             .to.emit(fermionFNFTProxy, "ExitPriceUpdated")
-            .withArgs(parseEther("3"), false)
+            .withArgs(parseEther("3"), false, 0)
             .and.to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized")
-            .withArgs(0, true);
+            .withArgs(0, true, 0);
         });
 
         it("should finalize correctly with edge-case quorum", async function () {
@@ -4494,7 +4494,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
 
-          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false);
+          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false, 0);
         });
 
         it("should finalize as failed when quorum is met but no votes are greater", async function () {
@@ -4508,7 +4508,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
 
-          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false);
+          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false, 0);
         });
 
         it("should finalize as failed when no votes are cast", async function () {
@@ -4520,7 +4520,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
 
-          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false);
+          await expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateProposalFinalized").withArgs(0, false, 0);
         });
 
         it("should stay ACTIVE when attempting to finalize before the deadline", async function () {

--- a/test/clients/fermionFractions.ts
+++ b/test/clients/fermionFractions.ts
@@ -3930,7 +3930,6 @@ describe("FermionFNFT - fractionalisation tests", function () {
             .withArgs(0, parseEther("2"), blockTimestamp + MIN_GOV_VOTE_DURATION, 7500);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
-          expect(proposal.proposalId).to.equal(0);
           expect(proposal.newExitPrice).to.equal(parseEther("2"));
           expect(proposal.votingDeadline).to.equal(blockTimestamp + MIN_GOV_VOTE_DURATION);
           expect(proposal.quorumPercent).to.equal(7500);
@@ -3946,7 +3945,6 @@ describe("FermionFNFT - fractionalisation tests", function () {
             .withArgs(0, parseEther("2"), blockTimestamp + DEFAULT_GOV_VOTE_DURATION, 7500);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
-          expect(proposal.proposalId).to.equal(0);
           expect(proposal.newExitPrice).to.equal(parseEther("2"));
           expect(proposal.votingDeadline).to.equal(blockTimestamp + DEFAULT_GOV_VOTE_DURATION);
           expect(proposal.quorumPercent).to.equal(7500);
@@ -3957,7 +3955,6 @@ describe("FermionFNFT - fractionalisation tests", function () {
           await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, DEFAULT_GOV_VOTE_DURATION);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
-          expect(proposal.proposalId).to.equal(0);
           expect(proposal.newExitPrice).to.equal(parseEther("2"));
           expect(proposal.yesVotes).to.equal(fractionsAmount);
           expect(proposal.noVotes).to.equal(0);
@@ -4010,7 +4007,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           expect(voterDetails.proposalId).to.equal(0);
           expect(voterDetails.voteCount).to.equal(owner1Balance);
 
-          tx = await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0);
+          tx = await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true);
 
           expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateVoted").withArgs(0, owner2.address, owner2Balance, true);
 
@@ -4026,7 +4023,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           let tx = await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION); // proposal id = 0
           expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateVoted").withArgs(0, owner1.address, owner1Balance, true);
           await setNextBlockTimestamp(Number((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1));
-          await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0); // finalize the proposal
+          await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true); // finalize the proposal
 
           let proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.yesVotes).to.equal(owner1Balance);
@@ -4047,7 +4044,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           tx = await fermionFNFTProxy.connect(owner2).updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION); // proposal id = 1
           expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateVoted").withArgs(1, owner2.address, owner2Balance, true);
 
-          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(false, 1);
+          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(1, false);
           expect(tx).to.emit(fermionFNFTProxy, "PriceUpdateVoted").withArgs(1, owner1.address, owner1Balance, false);
 
           proposal = await fermionFNFTProxy.getProposalDetails(1);
@@ -4082,7 +4079,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           const additionalFractions = parseEther("1");
           await erc20Clone.connect(owner2).transfer(owner1.address, additionalFractions);
 
-          await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true);
 
           proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.yesVotes).to.equal(owner1InitialBalance + additionalFractions);
@@ -4127,7 +4124,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           expect(voterDetails.voteCount).to.equal(0);
 
           // Step 5: Allow `owner2` to cast a vote with the newly acquired fractions
-          await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true);
 
           // Verify `proposal.noVotes` reflects the original total balance (transferred from `owner1` to `owner2`)
           const currentProposalDetails = await fermionFNFTProxy.getProposalDetails(0);
@@ -4135,7 +4132,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           // Step 6: Finalize the current proposal to allow creation of a new one
           await setNextBlockTimestamp(Number((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1));
-          await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0); // Finalize the proposal
+          await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true); // Finalize the proposal
 
           // Verify the proposal is finalized
           const finalizedProposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4168,7 +4165,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           // Step 2: Create a governance proposal and Owner1 votes NO
           await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION);
           await fermionFNFTProxy.removeVoteOnProposal(0);
-          await fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0);
+          await fermionFNFTProxy.connect(owner1).voteOnProposal(0, false);
 
           // Verify initial proposal state
           let proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4185,7 +4182,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           expect(owner1RemainingBalance).to.be.equal(voterDetails.voteCount - transferAmountA);
 
           // Step 4: Owner2 votes with the received A amount
-          await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true);
 
           proposal = await fermionFNFTProxy.getProposalDetails(0);
           let owner2VoterDetails = await fermionFNFTProxy.getVoterDetails(owner2.address);
@@ -4209,7 +4206,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           it("Double voting", async function () {
             await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION);
 
-            await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0)).to.be.revertedWithCustomError(
+            await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(0, true)).to.be.revertedWithCustomError(
               fermionFNFTProxy,
               "AlreadyVoted",
             );
@@ -4218,7 +4215,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           it("Voter has no fractions", async function () {
             await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION);
             const random = wallets[11]; //random wallet
-            await expect(fermionFNFTProxy.connect(random).voteOnProposal(true, 0)).to.be.revertedWithCustomError(
+            await expect(fermionFNFTProxy.connect(random).voteOnProposal(0, true)).to.be.revertedWithCustomError(
               fermionFNFTProxy,
               "NoVotingPower",
             );
@@ -4226,7 +4223,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           it("Voter changes vote direction", async function () {
             await fermionFNFTProxy.updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION);
-            await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0)).to.be.revertedWithCustomError(
+            await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(0, false)).to.be.revertedWithCustomError(
               fermionFNFTProxy,
               "ConflictingVote",
             );
@@ -4235,7 +4232,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             const erc20Clone = await getERC20Clone(fermionFNFTProxy);
             await erc20Clone.connect(owner1).transfer(owner2.address, parseEther("1"));
             await fermionFNFTProxy.connect(owner1).updateExitPrice(parseEther("2"), 7500, MIN_GOV_VOTE_DURATION);
-            await fermionFNFTProxy.connect(owner2).voteOnProposal(false, 0);
+            await fermionFNFTProxy.connect(owner2).voteOnProposal(0, false);
 
             await expect(fermionFNFTProxy.connect(owner2).updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION))
               .to.be.revertedWithCustomError(fermionFNFTProxy, "AlreadyVotedInProposal")
@@ -4249,7 +4246,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // send additional fractions to owner2
             await erc20Clone.connect(owner1).transfer(owner2.address, parseEther("1"));
             // owner2 should not be able to vote on proposal id = 0 as they have already voted in proposal id = 1
-            await expect(fermionFNFTProxy.connect(owner2).voteOnProposal(false, 0))
+            await expect(fermionFNFTProxy.connect(owner2).voteOnProposal(0, false))
               .to.be.revertedWithCustomError(fermionFNFTProxy, "AlreadyVotedInProposal")
               .withArgs(1);
           });
@@ -4263,7 +4260,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // Step 1: Cast a NO vote
             const owner1Balance = await balanceOfERC20(fermionFNFTProxy, owner1);
             await fermionFNFTProxy.removeVoteOnProposal(0);
-            await fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0);
+            await fermionFNFTProxy.connect(owner1).voteOnProposal(0, false);
 
             // Step 2: Verify the initial state of the proposal
             let proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4279,7 +4276,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // Verify emitted event
             await expect(tx)
               .to.emit(fermionFNFTProxy, "PriceUpdateVoteRemoved")
-              .withArgs(proposal.proposalId, owner1.address, owner1Balance, false);
+              .withArgs(0, owner1.address, owner1Balance, false);
 
             // Step 4: Verify the proposal state after vote removal
             proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4305,7 +4302,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             // Verify emitted event
             await expect(tx)
               .to.emit(fermionFNFTProxy, "PriceUpdateVoteRemoved")
-              .withArgs(proposal.proposalId, owner1.address, owner1Balance, true);
+              .withArgs(0, owner1.address, owner1Balance, true);
 
             // Step 3: Verify the proposal state after vote removal
             proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4318,7 +4315,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           it("should revert if the proposal is finalised", async function () {
             // Finalize the current proposal
             await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-            await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0); // Finalize the proposal
+            await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true); // Finalize the proposal
 
             // Attempt to remove a vote on a finalized proposal
             await expect(fermionFNFTProxy.connect(owner1).removeVoteOnProposal(0)).to.be.revertedWithCustomError(
@@ -4342,7 +4339,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
 
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
 
-          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0);
+          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Executed);
@@ -4367,7 +4364,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
             MIN_GOV_VOTE_DURATION,
           );
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-          await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0); // finalization
+          await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true); // finalization
 
           // Retrieve proposal details after finalization
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
@@ -4379,7 +4376,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           let tx = await fermionFNFTProxy.updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION);
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
           await fermionFNFTProxy.connect(owner1).removeVoteOnProposal(0);
-          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0); // Vote won't matter as quorum is not met.
+          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(0, false); // Vote won't matter as quorum is not met.
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
@@ -4390,10 +4387,10 @@ describe("FermionFNFT - fractionalisation tests", function () {
         it("should finalize as failed when quorum is met but no votes are greater", async function () {
           let tx = await fermionFNFTProxy.updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION);
           await fermionFNFTProxy.connect(owner1).removeVoteOnProposal(0);
-          await fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0); // Majority votes 'no'
+          await fermionFNFTProxy.connect(owner1).voteOnProposal(0, false); // Majority votes 'no'
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
 
-          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0);
+          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true);
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
@@ -4405,7 +4402,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           let tx = await fermionFNFTProxy.updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION);
           await fermionFNFTProxy.connect(owner1).removeVoteOnProposal(0);
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0); // Trigger finalization.
+          tx = await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true); // Trigger finalization.
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Failed);
@@ -4425,7 +4422,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           await erc20Clone.connect(owner1).transfer(owner2.address, transferAmount);
 
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION - 10);
-          await fermionFNFTProxy.connect(owner2).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(owner2).voteOnProposal(0, true);
 
           const updatedProposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(updatedProposal.state).to.equal(PriceUpdateProposalState.Active);
@@ -4433,7 +4430,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
         });
 
         it("should revert if proposal id is invalid", async function () {
-          await expect(fermionFNFTProxy.connect(owner2).voteOnProposal(true, 1)).to.be.revertedWithCustomError(
+          await expect(fermionFNFTProxy.connect(owner2).voteOnProposal(1, true)).to.be.revertedWithCustomError(
             fermionFNFTProxy,
             "InvalidProposalId",
           );
@@ -4442,12 +4439,12 @@ describe("FermionFNFT - fractionalisation tests", function () {
         it("should revert if a proposal is already finalized", async function () {
           const tx = await fermionFNFTProxy.updateExitPrice(parseEther("3"), 7500, MIN_GOV_VOTE_DURATION);
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-          await fermionFNFTProxy.connect(owner1).voteOnProposal(true, 0); // Trigger finalization.
+          await fermionFNFTProxy.connect(owner1).voteOnProposal(0, true); // Trigger finalization.
 
           const proposal = await fermionFNFTProxy.getProposalDetails(0);
           expect(proposal.state).to.equal(PriceUpdateProposalState.Executed);
 
-          await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(false, 0)).to.be.revertedWithCustomError(
+          await expect(fermionFNFTProxy.connect(owner1).voteOnProposal(0, false)).to.be.revertedWithCustomError(
             fermionFNFTProxy,
             "ProposalNotActive",
           );
@@ -4474,7 +4471,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           let tx = await fermionFNFTProxy.connect(seller).updateExitPrice(maxBid - 1n, 7500, MIN_GOV_VOTE_DURATION);
 
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-          await fermionFNFTProxy.connect(seller).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(seller).voteOnProposal(0, true);
 
           tx = await fermionFNFTProxy.startAuction(startTokenId);
 
@@ -4500,7 +4497,7 @@ describe("FermionFNFT - fractionalisation tests", function () {
           let tx = await fermionFNFTProxy.connect(seller).updateExitPrice(maxBid, 7500, MIN_GOV_VOTE_DURATION);
 
           await setNextBlockTimestamp((await getBlockTimestampFromTransaction(tx)) + MIN_GOV_VOTE_DURATION + 1);
-          await fermionFNFTProxy.connect(seller).voteOnProposal(true, 0);
+          await fermionFNFTProxy.connect(seller).voteOnProposal(0, true);
 
           tx = await fermionFNFTProxy.startAuction(startTokenId);
 

--- a/test/protocol/custodyVaultFacet.ts
+++ b/test/protocol/custodyVaultFacet.ts
@@ -52,6 +52,7 @@ describe("CustodyVault", function () {
   };
   const exchange = { tokenId: "", custodianId: "", price: 0n };
   const additionalDeposit = 0n;
+  const defaultEpoch = 0n;
 
   async function setupCustodyTest() {
     // Create three entities
@@ -447,11 +448,13 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "FractionsSetup")
-              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters));
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT);
+              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters), defaultEpoch);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue);
+              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue, defaultEpoch);
 
             // offer vault is created
             const expectedOfferVault = {
@@ -506,11 +509,13 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "FractionsSetup")
-              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters));
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT);
+              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters), defaultEpoch);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue);
+              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue, defaultEpoch);
 
             // offer vault is created
             const expectedOfferVault = {
@@ -575,11 +580,13 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "FractionsSetup")
-              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters));
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT);
+              .withArgs(DEFAULT_FRACTION_AMOUNT, Object.values(buyoutAuctionDefaultParameters), defaultEpoch);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, DEFAULT_FRACTION_AMOUNT, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue);
+              .withArgs(fractionsToIssue, DEFAULT_FRACTION_AMOUNT + fractionsToIssue, defaultEpoch);
 
             // offer vault is created
             const expectedOfferVault = {
@@ -683,10 +690,12 @@ describe("CustodyVault", function () {
               .to.emit(custodyVaultFacet, "AuctionStarted")
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2).to.not.emit(wrapper, "FractionsSetup");
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, fractionsPerToken);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, fractionsPerToken, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             // offer vault remains the same, just number of items is increased
             const expectedOfferVault = {
@@ -733,10 +742,12 @@ describe("CustodyVault", function () {
               .to.emit(custodyVaultFacet, "AuctionStarted")
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2).to.not.emit(wrapper, "FractionsSetup");
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, fractionsPerToken);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, fractionsPerToken, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             // offer vault remains the same, just number of items is increased
             const expectedOfferVault = {
@@ -792,10 +803,12 @@ describe("CustodyVault", function () {
               .to.emit(custodyVaultFacet, "AuctionStarted")
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2).to.not.emit(wrapper, "FractionsSetup");
-            await expect(tx2).to.emit(wrapper, "Fractionalised").withArgs(exchange.tokenId, fractionsPerToken);
+            await expect(tx2)
+              .to.emit(wrapper, "Fractionalised")
+              .withArgs(exchange.tokenId, fractionsPerToken, defaultEpoch);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, 2n * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             // offer vault remains the same, just number of items is increased
             const expectedOfferVault = {
@@ -2631,7 +2644,7 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             // offer vault remains the same
             const expectedOfferVault = {
@@ -2669,7 +2682,7 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             const expectedOfferVault = {
               amount: 0n,
@@ -2713,7 +2726,7 @@ describe("CustodyVault", function () {
               .withArgs(offerId, fractionsToIssue, auctionEnd);
             await expect(tx2)
               .to.emit(wrapper, "AdditionalFractionsMinted")
-              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue);
+              .withArgs(fractionsToIssue, tokenCount * fractionsPerToken + fractionsToIssue, defaultEpoch);
 
             // offer vault remains the same, just number of items is increased
             const expectedOfferVault = {


### PR DESCRIPTION
close #476 
close #509 

NOTE: Main changes in the Update Proposal Voting Mechanism apart from ones mention in #476 :
- on `updateExitPrice` the caller votes with all of his available fractions with `YES` vote. 