### PR TITLE
chore: ensure tokens are supported in the Local Environment

### DIFF
--- a/e2e/scripts/deploy.ts
+++ b/e2e/scripts/deploy.ts
@@ -8,6 +8,7 @@ import { readBosonConfig } from "./read-boson-config";
 import { setBosonConfig } from "./set-boson-config";
 import { deployBosonMetaTransactionFacet } from "./deploy-boson-meta-tx-facet";
 import { deployForwarderForBosonVouchers } from "./deploy-forwarder-for-boson-vouchers";
+import { ensureTokensAreSupported } from "./ensure-supported-tokens";
 
 // Set the Boson Protocol contracts compilation folder to the Boson Protocol contracts and compiles them.
 // Used to avoid artifacts clashes.
@@ -25,7 +26,7 @@ async function setBosonContractsCompilationFolder() {
 
 async function main() {
   const defaultSigner = (await hre.ethers.getSigners())[1];
-  const { bosonProtocolAddress } =
+  const { diamondAddress: fermionProtocolAddress, bosonProtocolAddress } =
     await deployFermionProtocolFixture.bind({ env: "test" })(defaultSigner);
 
   // deploy an ERC20 contract
@@ -49,8 +50,11 @@ async function main() {
   console.log("Deploy MetaTransactionHandlerFacet on Boson....");
   await deployBosonMetaTransactionFacet(bosonProtocolAddress);
 
-  console.log("Deploy a MockForwarder")
+  console.log("Deploy a MockForwarder");
   await deployForwarderForBosonVouchers(bosonProtocolAddress);
+
+  console.log("Ensure the deployed ERC20 tokens are supported");
+  await ensureTokensAreSupported(fermionProtocolAddress, [await erc20.getAddress(), tokenAddress]);
 }
 
 main()

--- a/e2e/scripts/ensure-supported-tokens.ts
+++ b/e2e/scripts/ensure-supported-tokens.ts
@@ -1,0 +1,45 @@
+import * as hre from "hardhat";
+import { Contract, TransactionReceipt, TransactionResponse } from "ethers";
+
+export async function ensureTokensAreSupported(fermionProtocolAddress: string, tokenAddresses: string[]) {
+  const deployer = (await hre.ethers.getSigners())[0];
+  const fermionOfferFacet = new Contract(
+    fermionProtocolAddress,
+    `[{
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_tokenAddress",
+          "type": "address"
+        }
+      ],
+      "name": "addSupportedToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }]`,
+    deployer
+  );
+  let oldNonce = -1;
+  const promises: Promise<TransactionReceipt | null>[] = [];
+  for (const tokenAddress of tokenAddresses) {
+    try {
+      let nonce = await deployer.getNonce();
+      while (nonce <= oldNonce) {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        nonce = await deployer.getNonce();
+      }
+      const tx =
+        (await fermionOfferFacet.addSupportedToken(tokenAddress, { nonce })) as TransactionResponse;
+      promises.push(tx.wait());
+      oldNonce = nonce;
+    } catch (e) {
+      // Allow the transaction to fail, when the exchangeToken is already supported by the DR
+      // (0x6c888286 = error DuplicateDisputeResolverFees())
+      if (e.reason !== "DuplicateDisputeResolverFees") {
+        throw e;
+      }
+    }
+  }
+  await Promise.all(promises);
+}


### PR DESCRIPTION
BEFORE the change, the ERC20 tokens deployed in the Local Environment Container are not added to the DR Supported tokens.
It means that every use of the container needs to add the prerequisite to call addSupportedToken().
Such need are IMHO adding useless constraints to the end users.
AFTER:
To make the use more seamless, I propose to automatically call addSupportedToken() for the ERC20 contracts being deployed in the container.


