### PR TITLE
Generate upgrade config to handle dependencies and generate 1.1.1 config

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "postinstall": "npx ts-node-transpile-only ./scripts/postinstall.ts"
   },
   "devDependencies": {
-    "@bosonprotocol/boson-protocol-contracts": "git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.2",
+    "@bosonprotocol/boson-protocol-contracts": "git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.3",
     "@bosonprotocol/common": "1.31.1-alpha.2",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@bosonprotocol/boson-protocol-contracts": "git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.2",
+    "@bosonprotocol/common": "1.31.1-alpha.2",
     "@nomicfoundation/hardhat-chai-matchers": "^2.1.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.0",
     "@nomicfoundation/hardhat-ignition": "^0.15.13",
@@ -57,7 +58,6 @@
     "urql": "^5.0.0"
   },
   "dependencies": {
-    "@bosonprotocol/common": "1.31.1-alpha.2",
     "@openzeppelin/contracts": "^5.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
     "@nomicfoundation/hardhat-verify": "^2.1.1",
     "@opensea/seaport-js": "^4.0.5",
-    "@openzeppelin/contracts-upgradeable": "^5.4.0",
     "@typechain/ethers-v6": "^0.5.0",
     "@typechain/hardhat": "^9.0.0",
     "@types/chai": "^4.2.0",
@@ -58,6 +57,7 @@
     "urql": "^5.0.0"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.4.0"
+    "@openzeppelin/contracts": "5.2.0",
+    "@openzeppelin/contracts-upgradeable": "5.2.0"
   }
 }

--- a/scripts/config/upgrades/1.1.1.json
+++ b/scripts/config/upgrades/1.1.1.json
@@ -1,0 +1,45 @@
+{
+  "description": "Upgrade to version 1.1.1",
+  "facets": {
+    "add": [],
+    "replace": ["MetaTransactionFacet", "OfferFacet", "VerificationFacet"],
+    "remove": [],
+    "constructorArgs": {
+      "MetaTransactionFacet": ["$FERMION_PROTOCOL_ADDRESS"],
+      "OfferFacet": ["$BOSON_PROTOCOL_ADDRESS"],
+      "VerificationFacet": [
+        "$BOSON_PROTOCOL_ADDRESS",
+        "$FERMION_PROTOCOL_ADDRESS"
+      ]
+    }
+  },
+  "clients": {
+    "fermionFNFT": []
+  },
+  "metaTxAllowlist": {
+    "add": [
+      {
+        "facetName": "MetaTransactionFacet",
+        "functionName": "executeMetaTransaction(address,string,bytes,uint256,bytes,uint256)",
+        "hash": "0x57b97cdb2fce0dee666819ee1160c69d7ccfb5c8e76df2aace281cbce2bb3caf"
+      },
+      {
+        "facetName": "VerificationFacet",
+        "functionName": "submitSignedProposal(uint256,uint16,bytes32,address,bytes)",
+        "hash": "0x520e63cfbd93b984b82d9fb3cec62cd0b8be9ee20aa123df492cd9dc448849b3"
+      }
+    ],
+    "remove": [
+      {
+        "facetName": "MetaTransactionFacet",
+        "functionName": "executeMetaTransaction(address,string,bytes,uint256,(bytes32,bytes32,uint8),uint256)",
+        "hash": "0xedb488173b6de59edb22e805aa39856285d4034a1ec670b83aa9a4d5108e79d2"
+      },
+      {
+        "facetName": "VerificationFacet",
+        "functionName": "submitSignedProposal(uint256,uint16,bytes32,address,(bytes32,bytes32,uint8))",
+        "hash": "0x9b8290f33fe4601cf79497c39a21cbb03feb5759124bac8ce5f3dbd289d55da7"
+      }
+    ]
+  }
+}

--- a/scripts/upgrade/generate-upgrade-config.ts
+++ b/scripts/upgrade/generate-upgrade-config.ts
@@ -59,11 +59,11 @@ async function getBytecodes(
     // package.json was checked out to store the list of production dependencies
     const packageJsonFile = fs.readFileSync(path.join(cwd, "package.json"), "utf-8");
     const packageJson = JSON.parse(packageJsonFile);
-    const {dependencies} = packageJson;
+    const { dependencies } = packageJson;
 
     // before installing them again with exact versions, checkout the current package.json again
     // to avoid any potential issues with other dependencies
-    shell.exec(`git checkout HEAD package.json`, { silent: true })
+    shell.exec(`git checkout HEAD package.json`, { silent: true });
 
     for (const [dep, ver] of Object.entries(dependencies)) {
       console.log(`Installing ${dep}@${ver.replace("^", "")}`);

--- a/scripts/upgrade/generate-upgrade-config.ts
+++ b/scripts/upgrade/generate-upgrade-config.ts
@@ -19,7 +19,7 @@ function isContractRelevantForAllowlist(name: string): boolean {
 
 async function getContractSelectors(contractName: string): Promise<Record<string, string>> {
   const contract = await hre.ethers.getContractFactory(contractName);
-  const selectors = await getSelectors(contract);
+  const selectors = getSelectors(contract);
   return selectors.reduce(
     (acc, selector) => {
       const func = contract.interface.getFunction(selector);
@@ -51,13 +51,25 @@ async function getBytecodes(
 
     // Checkout the version's contracts
     shell.exec(`rm -rf contracts`);
-    const checkoutResult = shell.exec(`git checkout ${version} contracts`, { silent: true });
+    const checkoutResult = shell.exec(`git checkout ${version} contracts package.json`, { silent: true });
     if (checkoutResult.code !== 0) {
       throw new Error(`Version ${version} does not exist in the repository`);
     }
 
-    // Install dependencies and compile
-    shell.exec("yarn install");
+    // package.json was checked out to store the list of production dependencies
+    const packageJsonFile = fs.readFileSync(path.join(cwd, "package.json"), "utf-8");
+    const packageJson = JSON.parse(packageJsonFile);
+    const {dependencies} = packageJson;
+
+    // before installing them again with exact versions, checkout the current package.json again
+    // to avoid any potential issues with other dependencies
+    shell.exec(`git checkout HEAD package.json`, { silent: true })
+
+    for (const [dep, ver] of Object.entries(dependencies)) {
+      console.log(`Installing ${dep}@${ver.replace("^", "")}`);
+      shell.exec(`yarn add ${dep}@${ver.replace("^", "")} --exact`, { silent: true });
+    }
+
     await hre.run("clean");
     try {
       await hre.run("compile");

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,13 +40,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
-"@bosonprotocol/boson-protocol-contracts@git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.1":
-  version "2.4.2"
-  resolved "git+https://github.com/bosonprotocol/boson-protocol-contracts#6a14c31bead936ed03b2d51ab82010ecd1047f40"
-  dependencies:
-    "@openzeppelin/contracts" "^4.9.6"
-    "@openzeppelin/contracts-upgradeable" "4.9.6"
-
 "@bosonprotocol/boson-protocol-contracts@git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.2":
   version "2.4.2"
   resolved "git+https://github.com/bosonprotocol/boson-protocol-contracts#efd5d1a8f23c3bca7c25273ea4c912a367250119"

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,9 +40,9 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
-"@bosonprotocol/boson-protocol-contracts@git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.2":
+"@bosonprotocol/boson-protocol-contracts@git+https://github.com/bosonprotocol/boson-protocol-contracts#v2.5.0-rc.3":
   version "2.4.2"
-  resolved "git+https://github.com/bosonprotocol/boson-protocol-contracts#efd5d1a8f23c3bca7c25273ea4c912a367250119"
+  resolved "git+https://github.com/bosonprotocol/boson-protocol-contracts#73585830fdd510f60608531a806591d94d939f90"
   dependencies:
     "@openzeppelin/contracts" "^4.9.6"
     "@openzeppelin/contracts-upgradeable" "4.9.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,20 +882,20 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz#38b21708a719da647de4bb0e4802ee235a0d24df"
   integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
 
-"@openzeppelin/contracts-upgradeable@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.4.0.tgz#a325066da702d0a8be091eb17136d3e9c92cc76a"
-  integrity sha512-STJKyDzUcYuB35Zub1JpWW58JxvrFFVgQ+Ykdr8A9PGXgtq/obF5uoh07k2XmFyPxfnZdPdBdhkJ/n2YxJ87HQ==
+"@openzeppelin/contracts-upgradeable@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.2.0.tgz#caf9a6eaf4f16d7f90f9b45a6db4e7b125f4b13b"
+  integrity sha512-mZIu9oa4tQTlGiOJHk6D3LdJlqFqF6oNOSn6S6UVJtzfs9UsY9/dhMEbAVTwElxUtJnjpf6yA062+oBp+eOyPg==
+
+"@openzeppelin/contracts@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.2.0.tgz#bd020694218202b811b0ea3eec07277814c658da"
+  integrity sha512-bxjNie5z89W1Ea0NZLZluFh8PrFNn9DH8DQlujEok2yjsOlraUPKID5p1Wk3qdNbf6XkQ1Os2RvfiHrrXLHWKA==
 
 "@openzeppelin/contracts@^4.9.6":
   version "4.9.6"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.6.tgz#2a880a24eb19b4f8b25adc2a5095f2aa27f39677"
   integrity sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==
-
-"@openzeppelin/contracts@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.4.0.tgz#177594bdb2d86c71f5d1052fe40cb4edb95fb20f"
-  integrity sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==
 
 "@pnpm/config.env-replace@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Close #538 

Note the OZ dependencies were downgraded to 5.2.0 version (matching the version used in protocol 1.1.0), to lower the number of contracts that needs to be upgraded in the upcoming small upgrade.

Using OZ@5.4.0 would additionally require the upgrade of the following contracts:
```
  'AccessController',
  'FermionBuyoutAuction',
  'FermionFNFT',
  'FermionFNFTPriceManager',
  'FermionFractionsERC20',
  'FermionFractionsMint',
  'SeaportWrapper',
  'ChainlinkPriceOracle',
  'CustodyFacet',
  'CustodyVaultFacet',
  'EntityFacet',
  'FundsFacet',
```
Logic in this contracs remains the same regardless of OZ version, it's just a minor implementation change that result in different bytecodes.