### PR TITLE
Release 1.1.1

### DIFF
--- a/addresses/1-ethereum-prod.json
+++ b/addresses/1-ethereum-prod.json
@@ -2,7 +2,7 @@
   "chainId": 1,
   "network": "ethereum",
   "env": "prod",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x0Bfb0BFffB4Fd23E61f5eeAfb6E48FcB9f79F6A1",
+      "address": "0xffEa4EC2be94A42C20cA2D899A7086770e1a9206",
       "args": ["0x93b330001bcaad603e21e2639fb041cdea472449"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x5eaCFbAe319231F6E43b27F96ad7Af210d176CF2",
+      "address": "0x64a70f3495A9A16084be9e68116E6bCB059E6E09",
       "args": ["0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xa023CB2B3270D5DA1bf927F7ba7D0E53F71Ce399",
+      "address": "0xEE469a05F6249aC97fdfBF714a0Fa2fBdfa5a756",
       "args": [
         "0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5",
         "0x93b330001bcaad603e21e2639fb041cdea472449"

--- a/addresses/10-optimism-prod.json
+++ b/addresses/10-optimism-prod.json
@@ -2,7 +2,7 @@
   "chainId": 10,
   "network": "optimism",
   "env": "prod",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0xDC7e4D34b27a7BB7f775177EdcF03a3C65921359",
+      "address": "0x64a70f3495A9A16084be9e68116E6bCB059E6E09",
       "args": ["0x93b330001bcaad603e21e2639fb041cdea472449"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x8Ef739f1cc3bA6ED8c06b0559feDDE6C3192EAC3",
+      "address": "0xc0DF5b8aE83AbB6481388Ff568698c597bfe9f04",
       "args": ["0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x1b9eE289514A285da0f92418D686378D4AD65E86",
+      "address": "0x050cc33100408dfA102600bD490BCC76692F0993",
       "args": [
         "0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5",
         "0x93b330001bcaad603e21e2639fb041cdea472449"

--- a/addresses/11155111-sepolia-staging.json
+++ b/addresses/11155111-sepolia-staging.json
@@ -2,7 +2,7 @@
   "chainId": 11155111,
   "network": "sepolia",
   "env": "staging",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -46,7 +46,9 @@
           {
             "facetAddress": "0x18F0c981E599042FB9C944561AA032961FAD9A53",
             "action": 0,
-            "functionSelectors": ["0x1f931c1c"]
+            "functionSelectors": [
+              "0x1f931c1c"
+            ]
           },
           {
             "facetAddress": "0xAfa3BDb593AcfeD6C70DE079bf16151c8Fb33C73",
@@ -74,7 +76,9 @@
           {
             "facetAddress": "0x00e400F45C85B38D21AEb76928f06bc317C2320d",
             "action": 0,
-            "functionSelectors": ["0x0d8e6e2c"]
+            "functionSelectors": [
+              "0x0d8e6e2c"
+            ]
           }
         ],
         {
@@ -95,17 +99,21 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0xF6310621F03F156D7BfF51202d3c3016114F6b69",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "address": "0x06632Ed3fFFd70fe775E1C8cA03f6C5b377e4cf7",
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "OfferFacet",
-      "address": "0xE187Cf3a854D7d91388cD4937c7E2e1F181f380E",
-      "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
+      "address": "0x7f3641A1ab40F6CbFbaC5D5D20BeE389721B2CF2",
+      "args": [
+        "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"
+      ]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xa6f49D3c01199C64E11919aA9941643Fe3C4a70f",
+      "address": "0x12499941B8c14181a76bfC82864654Ce2dbE1844",
       "args": [
         "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6",
         "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
@@ -160,7 +168,9 @@
     {
       "name": "FermionFractionsERC20",
       "address": "0xc49725B14bf67cac22D3438D7Cbdc29F54C1f83A",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "FermionFractionsMint",
@@ -174,7 +184,9 @@
     {
       "name": "FermionFNFTPriceManager",
       "address": "0x55c44a99Fd6495802624d9A35Ee4BFc8F8104DFC",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "FermionBuyoutAuction",

--- a/addresses/11155111-sepolia-staging.json
+++ b/addresses/11155111-sepolia-staging.json
@@ -46,9 +46,7 @@
           {
             "facetAddress": "0x18F0c981E599042FB9C944561AA032961FAD9A53",
             "action": 0,
-            "functionSelectors": [
-              "0x1f931c1c"
-            ]
+            "functionSelectors": ["0x1f931c1c"]
           },
           {
             "facetAddress": "0xAfa3BDb593AcfeD6C70DE079bf16151c8Fb33C73",
@@ -76,9 +74,7 @@
           {
             "facetAddress": "0x00e400F45C85B38D21AEb76928f06bc317C2320d",
             "action": 0,
-            "functionSelectors": [
-              "0x0d8e6e2c"
-            ]
+            "functionSelectors": ["0x0d8e6e2c"]
           }
         ],
         {
@@ -100,16 +96,12 @@
     {
       "name": "MetaTransactionFacet",
       "address": "0x06632Ed3fFFd70fe775E1C8cA03f6C5b377e4cf7",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "OfferFacet",
       "address": "0x7f3641A1ab40F6CbFbaC5D5D20BeE389721B2CF2",
-      "args": [
-        "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"
-      ]
+      "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
     },
     {
       "name": "VerificationFacet",
@@ -168,9 +160,7 @@
     {
       "name": "FermionFractionsERC20",
       "address": "0xc49725B14bf67cac22D3438D7Cbdc29F54C1f83A",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "FermionFractionsMint",
@@ -184,9 +174,7 @@
     {
       "name": "FermionFNFTPriceManager",
       "address": "0x55c44a99Fd6495802624d9A35Ee4BFc8F8104DFC",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "FermionBuyoutAuction",

--- a/addresses/11155111-sepolia-test.json
+++ b/addresses/11155111-sepolia-test.json
@@ -2,7 +2,7 @@
   "chainId": 11155111,
   "network": "sepolia",
   "env": "test",
-  "protocolVersion": "1.1.0-rc.4",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "DiamondCutFacet",
@@ -81,17 +81,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0xcbFb8951836B8905B5B7176d5B0dceDB251b8F92",
+      "address": "0x6D6cC841C3F0752d949350d7a2763a1Cfe5C0608",
       "args": ["0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"]
     },
     {
       "name": "OfferFacet",
-      "address": "0xE7975Cb1D07D2F37c0481bE0Ac4eA013377cb971",
+      "address": "0xbD9A4616824dC7B130b16443f7f2FCaecA9952E1",
       "args": ["0x7de418a7ce94debd057c34ebac232e7027634ade"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x3C8535c4767E6244ef783b1406D6692F4072B419",
+      "address": "0x5Cc9e6EA2cF3D8fE8b04fcE3d05e1Bf5d75FA35E",
       "args": [
         "0x7de418a7ce94debd057c34ebac232e7027634ade",
         "0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"

--- a/addresses/11155420-optimismsepolia-staging.json
+++ b/addresses/11155420-optimismsepolia-staging.json
@@ -2,7 +2,7 @@
   "chainId": 11155420,
   "network": "optimismSepolia",
   "env": "staging",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0xA840B53107E7140919FeFD40DedD7f9FDc24D78d",
+      "address": "0xD7D8A26a02565aC69d5Fcab72692331149a6B25A",
       "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x72762E3A9181F7Df6b0EbAE3825CC79D7E830d36",
+      "address": "0x4Ec9f3b10c8C039cD435E840f5ca6B92a83581D6",
       "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x423DED7234F45E67C0bF1F882C58fb9Fe68c2603",
+      "address": "0x296A6947a935f381c35e8DBC3f1B20E1eD058855",
       "args": [
         "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6",
         "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"

--- a/addresses/11155420-optimismsepolia-test.json
+++ b/addresses/11155420-optimismsepolia-test.json
@@ -2,7 +2,7 @@
   "chainId": 11155420,
   "network": "optimismSepolia",
   "env": "test",
-  "protocolVersion": "1.1.0-rc.4",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x743FEA9EBf0cA04b9d8F33A7EDb25124d443553f",
+      "address": "0xb984d98405a65bFc97bd535c07996C02CFEa6032",
       "args": ["0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"]
     },
     {
       "name": "OfferFacet",
-      "address": "0xFDbDE16F5631ee830aD314C744c68d07739E5665",
+      "address": "0xc06F2C0c5AB5739AcB95356f12ef6AeA8337F925",
       "args": ["0x7de418a7ce94debd057c34ebac232e7027634ade"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x70120Bf8605851b6015493397FeCB1C67CD60e28",
+      "address": "0x072e44B295Fd0fAeAA9C76237164b01dea92d239",
       "args": [
         "0x7de418a7ce94debd057c34ebac232e7027634ade",
         "0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"

--- a/addresses/137-polygon-prod.json
+++ b/addresses/137-polygon-prod.json
@@ -2,7 +2,7 @@
   "chainId": 137,
   "network": "polygon",
   "env": "prod",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x0Bfb0BFffB4Fd23E61f5eeAfb6E48FcB9f79F6A1",
+      "address": "0xffEa4EC2be94A42C20cA2D899A7086770e1a9206",
       "args": ["0x93b330001bcaad603e21e2639fb041cdea472449"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x5eaCFbAe319231F6E43b27F96ad7Af210d176CF2",
+      "address": "0x64a70f3495A9A16084be9e68116E6bCB059E6E09",
       "args": ["0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xa023CB2B3270D5DA1bf927F7ba7D0E53F71Ce399",
+      "address": "0xEE469a05F6249aC97fdfBF714a0Fa2fBdfa5a756",
       "args": [
         "0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5",
         "0x93b330001bcaad603e21e2639fb041cdea472449"

--- a/addresses/42161-arbitrum-prod.json
+++ b/addresses/42161-arbitrum-prod.json
@@ -2,7 +2,7 @@
   "chainId": 42161,
   "network": "arbitrum",
   "env": "prod",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "SeaportWrapper",
@@ -111,17 +111,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x0Bfb0BFffB4Fd23E61f5eeAfb6E48FcB9f79F6A1",
+      "address": "0xffEa4EC2be94A42C20cA2D899A7086770e1a9206",
       "args": ["0x93b330001bcaad603e21e2639fb041cdea472449"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x5eaCFbAe319231F6E43b27F96ad7Af210d176CF2",
+      "address": "0x64a70f3495A9A16084be9e68116E6bCB059E6E09",
       "args": ["0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xa023CB2B3270D5DA1bf927F7ba7D0E53F71Ce399",
+      "address": "0xEE469a05F6249aC97fdfBF714a0Fa2fBdfa5a756",
       "args": [
         "0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5",
         "0x93b330001bcaad603e21e2639fb041cdea472449"

--- a/addresses/421614-arbitrumsepolia-staging.json
+++ b/addresses/421614-arbitrumsepolia-staging.json
@@ -2,7 +2,7 @@
   "chainId": 421614,
   "network": "arbitrumSepolia",
   "env": "staging",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "SeaportWrapper",
@@ -111,17 +111,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x89CDaB3931332E2DDF163B90F400b47646142aaF",
+      "address": "0x4Eb76427a6464dba0E8cFBcA9d6362154a0cD17C",
       "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x6d7a25Edc3bB58867A7bcEcB83D8750c8e865db0",
+      "address": "0x8E14BCa38181A6948C45FaAb110E5721c74a4D35",
       "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xE0B22316bAca06d0AfA47bb3A0748DFA96Ffd1d6",
+      "address": "0xb984d98405a65bFc97bd535c07996C02CFEa6032",
       "args": [
         "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6",
         "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"

--- a/addresses/421614-arbitrumsepolia-test.json
+++ b/addresses/421614-arbitrumsepolia-test.json
@@ -2,7 +2,7 @@
   "chainId": 421614,
   "network": "arbitrumSepolia",
   "env": "test",
-  "protocolVersion": "1.1.0-rc.4",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "SeaportWrapper",
@@ -111,17 +111,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0xDDcE3Eaf5b0114bEbcabF55Daea043bB367655BE",
+      "address": "0xBaeA02F6a9f89766366f567C36FaA5a21436cf93",
       "args": ["0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"]
     },
     {
       "name": "OfferFacet",
-      "address": "0xd5F5DABE0439aae5a86E349e66Ae87c38B6580d1",
+      "address": "0xEA13bb67B969a2fb4fd95AC516a16e6aCe7b2f89",
       "args": ["0x7de418a7ce94debd057c34ebac232e7027634ade"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xeD2C5Fc86Ef2adE0e5A0965E275c4da489FB519F",
+      "address": "0x10Bf1BF8E31456137D441cAaB3021e5F89d42dA9",
       "args": [
         "0x7de418a7ce94debd057c34ebac232e7027634ade",
         "0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"

--- a/addresses/80002-amoy-staging.json
+++ b/addresses/80002-amoy-staging.json
@@ -2,7 +2,7 @@
   "chainId": 80002,
   "network": "amoy",
   "env": "staging",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -46,7 +46,9 @@
           {
             "facetAddress": "0x97E1fb9b4429Ab15271d456Df32a9D6895563fA8",
             "action": 0,
-            "functionSelectors": ["0x1f931c1c"]
+            "functionSelectors": [
+              "0x1f931c1c"
+            ]
           },
           {
             "facetAddress": "0xfF3cb0Ab4489f097090D96A653BCDa8365802Eae",
@@ -74,7 +76,9 @@
           {
             "facetAddress": "0xC9A5954337a7925AC7b3347285f5332fbA69d160",
             "action": 0,
-            "functionSelectors": ["0x0d8e6e2c"]
+            "functionSelectors": [
+              "0x0d8e6e2c"
+            ]
           }
         ],
         {
@@ -95,17 +99,21 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x3c79831F56231150Fd9c2A59eD627412F5578638",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "address": "0xe95952f770F0729FdAdD02498E3528b190B4122d",
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "OfferFacet",
-      "address": "0xDE307A82bE1b8929D59204153333C8f57d8D059c",
-      "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
+      "address": "0xF404f39F36Af010a4AB0155149A92ca4B644b38B",
+      "args": [
+        "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"
+      ]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x4A3280F53d1D1cB9ab1D6Cfe1a6E003c4F9f2520",
+      "address": "0x062c0A98b6CdA7b599aD7A96aA78D2F17ed85262",
       "args": [
         "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6",
         "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
@@ -160,7 +168,9 @@
     {
       "name": "FermionFractionsERC20",
       "address": "0x1aE85E901350141c143A1BACFD571D4972664fa9",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "FermionFractionsMint",
@@ -174,7 +184,9 @@
     {
       "name": "FermionFNFTPriceManager",
       "address": "0x37DDDAEAA10944C780882e6E9FE922e00613cc87",
-      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
+      "args": [
+        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
+      ]
     },
     {
       "name": "FermionBuyoutAuction",

--- a/addresses/80002-amoy-staging.json
+++ b/addresses/80002-amoy-staging.json
@@ -46,9 +46,7 @@
           {
             "facetAddress": "0x97E1fb9b4429Ab15271d456Df32a9D6895563fA8",
             "action": 0,
-            "functionSelectors": [
-              "0x1f931c1c"
-            ]
+            "functionSelectors": ["0x1f931c1c"]
           },
           {
             "facetAddress": "0xfF3cb0Ab4489f097090D96A653BCDa8365802Eae",
@@ -76,9 +74,7 @@
           {
             "facetAddress": "0xC9A5954337a7925AC7b3347285f5332fbA69d160",
             "action": 0,
-            "functionSelectors": [
-              "0x0d8e6e2c"
-            ]
+            "functionSelectors": ["0x0d8e6e2c"]
           }
         ],
         {
@@ -100,16 +96,12 @@
     {
       "name": "MetaTransactionFacet",
       "address": "0xe95952f770F0729FdAdD02498E3528b190B4122d",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "OfferFacet",
       "address": "0xF404f39F36Af010a4AB0155149A92ca4B644b38B",
-      "args": [
-        "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"
-      ]
+      "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
     },
     {
       "name": "VerificationFacet",
@@ -168,9 +160,7 @@
     {
       "name": "FermionFractionsERC20",
       "address": "0x1aE85E901350141c143A1BACFD571D4972664fa9",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "FermionFractionsMint",
@@ -184,9 +174,7 @@
     {
       "name": "FermionFNFTPriceManager",
       "address": "0x37DDDAEAA10944C780882e6E9FE922e00613cc87",
-      "args": [
-        "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"
-      ]
+      "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "FermionBuyoutAuction",

--- a/addresses/80002-amoy-test.json
+++ b/addresses/80002-amoy-test.json
@@ -2,7 +2,7 @@
   "chainId": 80002,
   "network": "amoy",
   "env": "test",
-  "protocolVersion": "1.1.0-rc.4",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "DiamondCutFacet",
@@ -81,17 +81,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x4ea72e99d2271C8a60A8e4F362B8B1aD84B2AC11",
+      "address": "0x4BAa027A10FeBbb5ca124388db3C8e6EC2a6d475",
       "args": ["0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x0947421Cd1406dEB8628b9680D3B33a35B39287f",
+      "address": "0x7a6DDD5e6805e2fd62687AFc8747cD7B506a830C",
       "args": ["0x7de418a7ce94debd057c34ebac232e7027634ade"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x37c68D0b6ec5d2E483133F03223608CFa6530233",
+      "address": "0x5344d8709Bd9404aaE980b534554D6622f5E7FE7",
       "args": [
         "0x7de418a7ce94debd057c34ebac232e7027634ade",
         "0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"

--- a/addresses/8453-base-prod.json
+++ b/addresses/8453-base-prod.json
@@ -2,7 +2,7 @@
   "chainId": 8453,
   "network": "base",
   "env": "prod",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "SeaportWrapper",
@@ -111,17 +111,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x16839583F26228EF344217CA153A2a32e091E155",
+      "address": "0xffEa4EC2be94A42C20cA2D899A7086770e1a9206",
       "args": ["0x93b330001bcaad603e21e2639fb041cdea472449"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x05f2b314CDeF513F9e51Bc762E7db315b99661DC",
+      "address": "0x64a70f3495A9A16084be9e68116E6bCB059E6E09",
       "args": ["0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0xd6115b0b7289EE6e7Ad3256BF11d8789A9dCFd96",
+      "address": "0xEE469a05F6249aC97fdfBF714a0Fa2fBdfa5a756",
       "args": [
         "0x59A4C19b55193D5a2EAD0065c54af4d516E18Cb5",
         "0x93b330001bcaad603e21e2639fb041cdea472449"

--- a/addresses/84532-basesepolia-staging.json
+++ b/addresses/84532-basesepolia-staging.json
@@ -2,7 +2,7 @@
   "chainId": 84532,
   "network": "baseSepolia",
   "env": "staging",
-  "protocolVersion": "1.1.0",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x4dbA4c64682e15a170B5483c363236f661bcD534",
+      "address": "0xc9FB729a36444a3adE4041eB48f21806bAa855B8",
       "args": ["0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x1BCAc66B40d3136a2050287EebDD752D4bfD42EC",
+      "address": "0x1e2c2908b76E0b18e9DF5021Ff704f3ECD04732b",
       "args": ["0x26f643746cbc918b46c2d47edca68c4a6c98ebe6"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x48f503C5584bc7794A3268b8717247AC37A3A8D6",
+      "address": "0xF816502a694d5C62b822A1Cc5406C0c3a6966055",
       "args": [
         "0x26f643746cbc918b46c2d47edca68c4a6c98ebe6",
         "0xe6434c187b1c0ed9e7fd2f54cf2d497378d9a2d8"

--- a/addresses/84532-basesepolia-test.json
+++ b/addresses/84532-basesepolia-test.json
@@ -2,7 +2,7 @@
   "chainId": 84532,
   "network": "baseSepolia",
   "env": "test",
-  "protocolVersion": "1.1.0-rc.4",
+  "protocolVersion": "1.1.1",
   "contracts": [
     {
       "name": "FermionFNFT",
@@ -95,17 +95,17 @@
     },
     {
       "name": "MetaTransactionFacet",
-      "address": "0x5ff802b0e7995c5CbDe1A3d88dDcC6f690726AC6",
+      "address": "0xA0C4183e042f18D2f6205978AF52f73a29D0a985",
       "args": ["0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"]
     },
     {
       "name": "OfferFacet",
-      "address": "0x423646D50C460E060f64384C1f8559e158a36Fd1",
+      "address": "0xDE31FBB4A7670F9F6A8cE7df0879116250ee78C5",
       "args": ["0x7de418a7ce94debd057c34ebac232e7027634ade"]
     },
     {
       "name": "VerificationFacet",
-      "address": "0x0346FCb5f30C0c639C5bed3cBD53A8423743775D",
+      "address": "0x9d7679d6A478fCD577227Fcd99DE362e746A100C",
       "args": [
         "0x7de418a7ce94debd057c34ebac232e7027634ade",
         "0x855a579601fb936eea4bc9c9ad7aa5d87d1b7585"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fermionprotocol/contracts",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fermion Protocol core verification mechanism",
   "main": "index.js",
   "repository": "git@github.com:fermionprotocol/contracts.git",

--- a/scripts/config/upgrades/1.1.1.json
+++ b/scripts/config/upgrades/1.1.1.json
@@ -19,22 +19,12 @@
   "metaTxAllowlist": {
     "add": [
       {
-        "facetName": "MetaTransactionFacet",
-        "functionName": "executeMetaTransaction(address,string,bytes,uint256,bytes,uint256)",
-        "hash": "0x57b97cdb2fce0dee666819ee1160c69d7ccfb5c8e76df2aace281cbce2bb3caf"
-      },
-      {
         "facetName": "VerificationFacet",
         "functionName": "submitSignedProposal(uint256,uint16,bytes32,address,bytes)",
         "hash": "0x520e63cfbd93b984b82d9fb3cec62cd0b8be9ee20aa123df492cd9dc448849b3"
       }
     ],
     "remove": [
-      {
-        "facetName": "MetaTransactionFacet",
-        "functionName": "executeMetaTransaction(address,string,bytes,uint256,(bytes32,bytes32,uint8),uint256)",
-        "hash": "0xedb488173b6de59edb22e805aa39856285d4034a1ec670b83aa9a4d5108e79d2"
-      },
       {
         "facetName": "VerificationFacet",
         "functionName": "submitSignedProposal(uint256,uint16,bytes32,address,(bytes32,bytes32,uint8))",

--- a/scripts/libraries/metaTransaction.ts
+++ b/scripts/libraries/metaTransaction.ts
@@ -44,6 +44,7 @@ export const RESTRICTED_METATX_FUNCTIONS = [
   "startAuctionInternal(uint256)",
   "transferFractionsFrom(address,address,uint256)",
   "renounceOwnership()",
+  "executeMetaTransaction"
 ];
 
 // Generic meta transaction type

--- a/scripts/libraries/metaTransaction.ts
+++ b/scripts/libraries/metaTransaction.ts
@@ -44,7 +44,7 @@ export const RESTRICTED_METATX_FUNCTIONS = [
   "startAuctionInternal(uint256)",
   "transferFractionsFrom(address,address,uint256)",
   "renounceOwnership()",
-  "executeMetaTransaction"
+  "executeMetaTransaction",
 ];
 
 // Generic meta transaction type

--- a/scripts/upgrade-hooks/1.1.1.ts
+++ b/scripts/upgrade-hooks/1.1.1.ts
@@ -1,0 +1,64 @@
+import { encodeBytes32String } from "ethers";
+import hre from "hardhat";
+import { readContracts } from "../libraries/utils";
+import { FacetConfig } from "../upgrade/upgrade-facets";
+const { ethers } = hre;
+
+// Function to get the InitializationFacet address based on chainId and env
+export async function getInitializationFacetAddress(chainId: number, env: string): Promise<string> {
+  const addressData = await readContracts(env);
+  const initializationFacet = addressData.contracts.find((contract: any) => contract.name === "InitializationFacet");
+
+  if (!initializationFacet) {
+    throw new Error(`InitializationFacet not found in addresses file for chainId ${chainId} and env ${env}`);
+  }
+
+  return initializationFacet.address;
+}
+
+/**
+ * Perform pre-upgrade tasks, including deploying the BackfillingV1_1_0 contract,
+ * preparing initialization data, and making the diamond cut.
+ */
+export async function preUpgrade(
+  protocolAddress: string,
+  chainId: number,
+  env: string,
+  version: string,
+  config: FacetConfig | undefined,
+  isDryRun: boolean = false,
+) {
+  const versionBytes = encodeBytes32String(version);
+  // Use the correct environment name based on whether we're in dry-run mode
+  const envForContracts = isDryRun ? `${env}-dry-run` : env;
+  const initializationFacetImplAddress = await getInitializationFacetAddress(chainId, envForContracts);
+  console.log(`InitializationFacet implementation address: ${initializationFacetImplAddress}`);
+
+  const addresses: string[] = [];
+  const calldata: string[] = [];
+  const interfacesToAdd: string[] = [];
+  const interfacesToRemove: string[] = [];
+
+  // Get the initialization facet to encode the calldata properly
+  const initializationFacet = await ethers.getContractAt("InitializationFacet", protocolAddress);
+  const initCalldata = initializationFacet.interface.encodeFunctionData("initialize", [
+    versionBytes,
+    addresses,
+    calldata,
+    interfacesToAdd,
+    interfacesToRemove,
+  ]);
+
+  config.initializationAddress = initializationFacetImplAddress;
+  config.initializationData = initCalldata;
+}
+
+/**
+ * Perform post-upgrade tasks, including verification of the upgrade.
+ */
+export async function postUpgrade(protocolAddress: string) {
+  console.log("Verifying upgrade...");
+  const initializationFacet = await ethers.getContractAt("InitializationFacet", protocolAddress);
+  const version = await initializationFacet.getVersion();
+  console.log(`Verified version: ${version.replace(/\0/g, "")}`);
+}

--- a/scripts/upgrade/generate-upgrade-config.ts
+++ b/scripts/upgrade/generate-upgrade-config.ts
@@ -176,6 +176,9 @@ async function generateUpgradeConfig(
       }
     }
 
+    // Prepare initialization data for facets with init functions
+    const initializationData: string = "0x"; // Placeholder, can be extended to include actual init calls if needed
+
     const relevantNewContracts = newContracts.filter(
       (contract) =>
         isContractRelevantForAllowlist(contract) && !contract.includes("/test/") && !contract.includes("Mock"),
@@ -269,6 +272,7 @@ async function generateUpgradeConfig(
           }),
         ],
       },
+      initializationData: initializationData,
       metaTxAllowlist: {
         add: finalMetaTxAllowlistAdd,
         remove: finalMetaTxAllowlistRemove,


### PR DESCRIPTION
Deployment status

| | test | staging | prod |
| :-- | :-: | :-: | :-: |
| polygon | X |  X | X | 
| ethereum | X |  X | X | 
| base | X |  X | X | 
| arbitrum | X  |  X | X | 
| optimism | X  |  X | X | 

Other changes:
- added `executeMetaTransaction` to restricted metatx list
- add 1.1.1 preupgrade hook which prepares the correct initialisation data 